### PR TITLE
Updates to resources and guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ columns:
 2`curie` the compact uniform resource identifier (CURIE) for a biomedical
    entity or concept, standardized using the Bioregistry
 3. `type` the match type, written as a CURIE from
-   the [`skos`](https://bioregistry.io/skos) controlled vocabulary, i.e., one
+   the [`oio`](https://bioregistry.io/oio) controlled vocabulary, i.e., one
    of:
-    - `skos:exactMatch`
-    - `skos:broadMatch`
-    - `skos:narrowMatch`
+    - `oio:hasExactSynonym`
+    - `oio:hasNarrowSynonym`
+    - `oio:hasBroadSynonym`
+    - `oio:hasRelatedSynonym`
+    - `oio:hasSynonym`
 4. `references` a comma-delimited list of CURIEs corresponding to publications
    that use the given synonym (ideally using highly actionable identifiers from
    semantic spaces like [`pubmed`](https://bioregistry.io/pubmed),
@@ -29,8 +31,8 @@ Here's an example of some rows in the synonyms table (with linkified CURIEs):
 
 | text                            | curie                                             | type                                                      | references                                                                                                           | contributor_orcid   |
 |---------------------------------|---------------------------------------------------|-----------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|---------------------|
-| PI(3,4,5)P3                     | [CHEBI:16618](https://bioregistry.io/CHEBI:16618) | [skos:exactMatch](https://bioregistry.io/skos:exactMatch) | [pubmed:29623928](https://bioregistry.io/pubmed:29623928), [pubmed:20817957](https://bioregistry.io/pubmed:20817957) | 0000-0003-4423-4370 |
-| phosphatidylinositol (3,4,5) P3 | [CHEBI:16618](https://bioregistry.io/CHEBI:16618) | [skos:exactMatch](https://bioregistry.io/skos:exactMatch) | [pubmed:29695532](https://bioregistry.io/pubmed:29695532)                                                            | 0000-0003-4423-4370 | 
+| PI(3,4,5)P3                     | [CHEBI:16618](https://bioregistry.io/CHEBI:16618) | [oio:hasExactSynonym](https://bioregistry.io/oio:hasExactSynonym) | [pubmed:29623928](https://bioregistry.io/pubmed:29623928), [pubmed:20817957](https://bioregistry.io/pubmed:20817957) | 0000-0003-4423-4370 |
+| phosphatidylinositol (3,4,5) P3 | [CHEBI:16618](https://bioregistry.io/CHEBI:16618) | [oio:hasExactSynonym](https://bioregistry.io/oio:hasExactSynonym) | [pubmed:29695532](https://bioregistry.io/pubmed:29695532)                                                            | 0000-0003-4423-4370 | 
 
 ### Incorrect Synonyms
 
@@ -39,7 +41,7 @@ columns for non-trivial examples of text strings that aren't synonyms. This
 document doesn't address the same issues as context-based disambiguation, but
 rather helps dscribe issues like incorrect sub-string matching:
 
-1. `negative_text` the non-synonym text itself
+1. `text` the non-synonym text itself
 2. `curie` the compact uniform resource identifier (CURIE) for a biomedical
    entity or concept that **does not** match the following text, standardized
    using the Bioregistry

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ license so they can be easily adopted by/contributed back to upstream resources.
 The [`positives.tsv`](src/biosynonyms/resources/positives.tsv) has the following
 columns:
 
-1`text` the synonym text itself
-2`curie` the compact uniform resource identifier (CURIE) for a biomedical
+1. `text` the synonym text itself
+2. `curie` the compact uniform resource identifier (CURIE) for a biomedical
    entity or concept, standardized using the Bioregistry
 3. `type` the match type, written as a CURIE from
    the [`oio`](https://bioregistry.io/oio) controlled vocabulary, i.e., one
@@ -29,8 +29,8 @@ columns:
 
 Here's an example of some rows in the synonyms table (with linkified CURIEs):
 
-| text                            | curie                                             | type                                                      | references                                                                                                           | contributor_orcid   |
-|---------------------------------|---------------------------------------------------|-----------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|---------------------|
+| text                            | curie                                             | type                                                              | references                                                                                                           | contributor_orcid   |
+|---------------------------------|---------------------------------------------------|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|---------------------|
 | PI(3,4,5)P3                     | [CHEBI:16618](https://bioregistry.io/CHEBI:16618) | [oio:hasExactSynonym](https://bioregistry.io/oio:hasExactSynonym) | [pubmed:29623928](https://bioregistry.io/pubmed:29623928), [pubmed:20817957](https://bioregistry.io/pubmed:20817957) | 0000-0003-4423-4370 |
 | phosphatidylinositol (3,4,5) P3 | [CHEBI:16618](https://bioregistry.io/CHEBI:16618) | [oio:hasExactSynonym](https://bioregistry.io/oio:hasExactSynonym) | [pubmed:29695532](https://bioregistry.io/pubmed:29695532)                                                            | 0000-0003-4423-4370 | 
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ columns:
 4. `references` a comma-delimited list of CURIEs corresponding to publications
    that use the given synonym (ideally using highly actionable identifiers from
    semantic spaces like [`pubmed`](https://bioregistry.io/pubmed),
-   [`pmc`](https://bioregistry.io/pmc), [`doi`](https://bioregistry.ip/doi))
+   [`pmc`](https://bioregistry.io/pmc), [`doi`](https://bioregistry.io/doi))
 5. `contributor_orcid` the ORCID identifier of the contributor
 
 Here's an example of some rows in the synonyms table (with linkified CURIEs):

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ columns:
 2. `curie` the compact uniform resource identifier (CURIE) for a biomedical
    entity or concept, standardized using the Bioregistry
 3. `type` the match type, written as a CURIE from
-   the [`oio`](https://bioregistry.io/oio) controlled vocabulary, i.e., one
-   of:
+   the [OBO in OWL (`oio`)](https://bioregistry.io/oio) controlled vocabulary,
+   i.e., one of:
     - `oio:hasExactSynonym`
     - `oio:hasNarrowSynonym`
     - `oio:hasBroadSynonym`
@@ -24,7 +24,7 @@ columns:
 4. `references` a comma-delimited list of CURIEs corresponding to publications
    that use the given synonym (ideally using highly actionable identifiers from
    semantic spaces like [`pubmed`](https://bioregistry.io/pubmed),
-   [`pmc`](https://bioregistry.io/pmc), [`doi`](https://bioregistry.i/doi))
+   [`pmc`](https://bioregistry.io/pmc), [`doi`](https://bioregistry.ip/doi))
 5. `contributor_orcid` the ORCID identifier of the contributor
 
 Here's an example of some rows in the synonyms table (with linkified CURIEs):

--- a/src/biosynonyms/lint.py
+++ b/src/biosynonyms/lint.py
@@ -2,13 +2,13 @@
 
 from pathlib import Path
 
-from .resources import NEGATIVES_PATH, POSITIVES_PATH
+from .resources import NEGATIVES_PATH, POSITIVES_PATH, sort_key
 
 
 def _sort(path: Path):
     with path.open() as file:
         header, *rows = [line.strip().split("\t") for line in file]
-    rows = sorted(rows)
+    rows = sorted(rows, key=sort_key)
     with path.open("w") as file:
         print(*header, sep="\t", file=file)  # noqa:T201
         for row in rows:

--- a/src/biosynonyms/resources/__init__.py
+++ b/src/biosynonyms/resources/__init__.py
@@ -5,8 +5,14 @@ from pathlib import Path
 __all__ = [
     "POSITIVES_PATH",
     "NEGATIVES_PATH",
+    "sort_key",
 ]
 
 HERE = Path(__file__).parent.resolve()
 POSITIVES_PATH = HERE.joinpath("positives.tsv")
 NEGATIVES_PATH = HERE.joinpath("negatives.tsv")
+
+
+def sort_key(row):
+    """Return a key for sorting a row."""
+    return (row[0].casefold(), row[0], row[1].casefold(), row[1])

--- a/src/biosynonyms/resources/positives.tsv
+++ b/src/biosynonyms/resources/positives.tsv
@@ -1,4 +1,4 @@
 text	curie	type	references	contributor_orcid
 PI(3,4,5)P3	CHEBI:16618	oio:hasExactSynonym	pubmed:29623928,pubmed:20817957,pubmed:18931680,pubmed:28443090	0000-0003-4423-4370
-phosphatidylinositol (3,4,5) P3	CHEBI:16618	oio:hasExactSynonym	pubmed:29695532	0000-0003-4423-4370
 abema	mesh:C000590451	oio:hasExactSynonym		0000-0001-9439-5346
+phosphatidylinositol (3,4,5) P3	CHEBI:16618	oio:hasExactSynonym	pubmed:29695532	0000-0003-4423-4370

--- a/src/biosynonyms/resources/positives.tsv
+++ b/src/biosynonyms/resources/positives.tsv
@@ -1,4 +1,4 @@
 text	curie	type	references	contributor_orcid
-PI(3,4,5)P3	CHEBI:16618	skos:exactMatch	pubmed:29623928,pubmed:20817957,pubmed:18931680,pubmed:28443090	0000-0003-4423-4370
-phosphatidylinositol (3,4,5) P3	CHEBI:16618	skos:exactMatch	pubmed:29695532	0000-0003-4423-4370
+PI(3,4,5)P3	CHEBI:16618	oio:hasExactSynonym	pubmed:29623928,pubmed:20817957,pubmed:18931680,pubmed:28443090	0000-0003-4423-4370
+phosphatidylinositol (3,4,5) P3	CHEBI:16618	oio:hasExactSynonym	pubmed:29695532	0000-0003-4423-4370
 abema	mesh:C000590451	oio:hasExactSynonym		0000-0001-9439-5346

--- a/src/biosynonyms/resources/positives.tsv
+++ b/src/biosynonyms/resources/positives.tsv
@@ -1,4 +1,4 @@
-negative_text	curie	type	references	contributor_orcid
+text	curie	type	references	contributor_orcid
 PI(3,4,5)P3	CHEBI:16618	skos:exactMatch	pubmed:29623928,pubmed:20817957,pubmed:18931680,pubmed:28443090	0000-0003-4423-4370
 phosphatidylinositol (3,4,5) P3	CHEBI:16618	skos:exactMatch	pubmed:29695532	0000-0003-4423-4370
 abema	mesh:C000590451	oio:hasExactSynonym		0000-0001-9439-5346

--- a/src/biosynonyms/resources/positives.tsv
+++ b/src/biosynonyms/resources/positives.tsv
@@ -1,4 +1,4 @@
 text	curie	type	references	contributor_orcid
-PI(3,4,5)P3	CHEBI:16618	oio:hasExactSynonym	pubmed:29623928,pubmed:20817957,pubmed:18931680,pubmed:28443090	0000-0003-4423-4370
 abema	mesh:C000590451	oio:hasExactSynonym		0000-0001-9439-5346
 phosphatidylinositol (3,4,5) P3	CHEBI:16618	oio:hasExactSynonym	pubmed:29695532	0000-0003-4423-4370
+PI(3,4,5)P3	CHEBI:16618	oio:hasExactSynonym	pubmed:29623928,pubmed:20817957,pubmed:18931680,pubmed:28443090	0000-0003-4423-4370

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -8,9 +8,11 @@ import bioregistry
 from biosynonyms.resources import NEGATIVES_PATH, POSITIVES_PATH
 
 SYNONYM_TYPES = {
-    "skos:exactMatch",
-    "skos:broadMatch",
-    "skos:narrowMatch",
+    "oio:hasExactSynonym",
+    "oio:hasNarrowSynonym",
+    "oio:hasBroadSynonym",
+    "oio:hasRelatedSynonym",
+    "oio:hasSynonym",
 }
 
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -5,7 +5,7 @@ from collections import Counter
 
 import bioregistry
 
-from biosynonyms.resources import NEGATIVES_PATH, POSITIVES_PATH
+from biosynonyms.resources import NEGATIVES_PATH, POSITIVES_PATH, sort_key
 
 SYNONYM_TYPES = {
     "oio:hasExactSynonym",
@@ -55,7 +55,7 @@ class TestIntegrity(unittest.TestCase):
                 self.assert_curie(f"orcid:{orcid}")
 
         # test sorted
-        self.assertEqual(sorted(rows), rows, msg="synonyms are not properly sorted")
+        self.assertEqual(sorted(rows, key=sort_key), rows, msg="synonyms are not properly sorted")
 
         # test no duplicates
         c = Counter(row[:2] for row in rows)
@@ -79,7 +79,9 @@ class TestIntegrity(unittest.TestCase):
                 self.assert_curie(f"orcid:{orcid}")
 
         # test sorted
-        self.assertEqual(sorted(rows), rows, msg="negative synonyms are not properly sorted")
+        self.assertEqual(
+            sorted(rows, key=sort_key), rows, msg="negative synonyms are not properly sorted"
+        )
 
         # test no duplicates
         c = Counter(row[:2] for row in rows)

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -49,7 +49,7 @@ class TestIntegrity(unittest.TestCase):
                 self.assertLess(1, len(text), msg="can not have 1 letter synonyms")
                 self.assert_curie(curie)
                 self.assertIn(stype, SYNONYM_TYPES)
-                for reference in references.split(","):
+                for reference in references.split(",") if references else []:
                     reference = reference.strip()
                     self.assert_curie(reference)
                 self.assert_curie(f"orcid:{orcid}")


### PR DESCRIPTION
This PR makes the following changes:
- Changes the README and the positive mappings file to use `oio` synonym relations instead of `skos` relations.
- Standardize column names between the positive and negative mappings files.

It might make sense to also add a `type` column to the negatives file but this PR doesn't change that for now.