### PR TITLE
Extend data model and create OWL export

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.8", "3.11" ]
+        python-version: [ "3.9", "3.12" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.8", "3.11" ]
+        python-version: [ "3.9", "3.12" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install tox
+        run: pip install tox tox-uv
       - name: Check manifest
         run: tox run -e manifest
       - name: Check code quality with flake8
@@ -58,7 +58,6 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         python-version: [ "3.8", "3.11" ]
-        pydantic: [ "1", "2" ]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -66,10 +65,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install tox
+        run: pip install tox tox-uv
       - name: Test with pytest and generate coverage file
         run:
-          tox run -e py-pydantic${{ matrix.pydantic }}
+          tox run -e py}
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v1
         if: success()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
         run: pip install tox tox-uv
       - name: Test with pytest and generate coverage file
         run:
-          tox run -e py}
+          tox run -e py
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v1
         if: success()

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ Temporary Items
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
 # User-specific stuff
+.idea
 .idea/**/workspace.xml
 .idea/**/tasks.xml
 .idea/**/usage.statistics.xml
@@ -319,3 +320,4 @@ tags
 scratch/
 docs/img/*.png
 docs/img/*.eps
+exports/qualo_synonyms.ttl

--- a/.gitignore
+++ b/.gitignore
@@ -320,4 +320,3 @@ tags
 scratch/
 docs/img/*.png
 docs/img/*.eps
-exports/qualo_synonyms.ttl

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ columns:
 2. `curie` the compact uniform resource identifier (CURIE) for a biomedical
    entity or concept, standardized using the Bioregistry
 3. `name` the standard name for the concept
-4. `predicate` the predicate which encodes the synonym scope, written as a CURIE from
+4. `scope` the predicate which encodes the synonym scope, written as a CURIE from
    the [OBO in OWL (`oio`)](https://bioregistry.io/oio) controlled vocabulary,
    i.e., one of:
     - `oboInOwl:hasExactSynonym`

--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ columns:
 2. `curie` the compact uniform resource identifier (CURIE) for a biomedical
    entity or concept, standardized using the Bioregistry
 3. `name` the standard name for the concept
-4. `scope` the match type, written as a CURIE from
+4. `predicate` the predicate which encodes the synonym scope, written as a CURIE from
    the [OBO in OWL (`oio`)](https://bioregistry.io/oio) controlled vocabulary,
    i.e., one of:
     - `oboInOwl:hasExactSynonym`
-    - `oboInOwl:hasNarrowSynonym`
-    - `oboInOwl:hasBroadSynonym`
+    - `oboInOwl:hasNarrowSynonym` (i.e., the synonym represents a narrower term)
+    - `oboInOwl:hasBroadSynonym` (i.e., the synonym represents a broader term)
     - `oboInOwl:hasRelatedSynonym`
     - `oboInOwl:hasSynonym` (use this if the scope is unknown)
-5. `type` the synonym property type, written as a CURIE from
+5. `type` the (optional) synonym property type, written as a CURIE from
    the [OBO Metadata Ontology (`omo`)](https://bioregistry.io/omo) controlled vocabulary,
    e.g., one of:
     - `OMO:0003000` (abbreviation)
@@ -49,18 +49,19 @@ columns:
     - `OMO:0003003` (layperson synonym)
     - `OMO:0003004` (plural form)
     - ...
-6. `references` a comma-delimited list of CURIEs corresponding to publications
+6. `provenance` a comma-delimited list of CURIEs corresponding to publications
    that use the given synonym (ideally using highly actionable identifiers from
    semantic spaces like [`pubmed`](https://bioregistry.io/pubmed),
    [`pmc`](https://bioregistry.io/pmc), [`doi`](https://bioregistry.io/doi))
 7. `contributor` the ORCID identifier of the contributor
+8. `language` the (optional) ISO 2-letter language code. If missing, assumed to be American English.
 
 Here's an example of some rows in the synonyms table (with linkified CURIEs):
 
-| text                            | curie                                             | scope                                                             | references                                                                                                           | contributor                                                             |
-|---------------------------------|---------------------------------------------------|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-| PI(3,4,5)P3                     | [CHEBI:16618](https://bioregistry.io/CHEBI:16618) | [oio:hasExactSynonym](https://bioregistry.io/oio:hasExactSynonym) | [pubmed:29623928](https://bioregistry.io/pubmed:29623928), [pubmed:20817957](https://bioregistry.io/pubmed:20817957) | [0000-0003-4423-4370](https://bioregistry.io/orcid:0000-0003-4423-4370) |
-| phosphatidylinositol (3,4,5) P3 | [CHEBI:16618](https://bioregistry.io/CHEBI:16618) | [oio:hasExactSynonym](https://bioregistry.io/oio:hasExactSynonym) | [pubmed:29695532](https://bioregistry.io/pubmed:29695532)                                                            | [0000-0003-4423-4370](https://bioregistry.io/orcid:0000-0003-4423-4370) | 
+| text                            | curie                                             | scope                                                             | provenance                                                                                                           | contributor                                                             | language |
+|---------------------------------|---------------------------------------------------|-------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|----------|
+| PI(3,4,5)P3                     | [CHEBI:16618](https://bioregistry.io/CHEBI:16618) | [oio:hasExactSynonym](https://bioregistry.io/oio:hasExactSynonym) | [pubmed:29623928](https://bioregistry.io/pubmed:29623928), [pubmed:20817957](https://bioregistry.io/pubmed:20817957) | [0000-0003-4423-4370](https://bioregistry.io/orcid:0000-0003-4423-4370) | en       |
+| phosphatidylinositol (3,4,5) P3 | [CHEBI:16618](https://bioregistry.io/CHEBI:16618) | [oio:hasExactSynonym](https://bioregistry.io/oio:hasExactSynonym) | [pubmed:29695532](https://bioregistry.io/pubmed:29695532)                                                            | [0000-0003-4423-4370](https://bioregistry.io/orcid:0000-0003-4423-4370) | en       |
 
 ### Incorrect Synonyms
 
@@ -76,13 +77,14 @@ rather helps dscribe issues like incorrect sub-string matching:
 3. `references` same as for `positives.tsv`, illustrating documents where this
    string appears
 4. `contributor` the ORCID identifier of the contributor
+5. `language` the (optional) ISO 2-letter language code. If missing, assumed to be American English.
 
 Here's an example of some rows in the negative synonyms table (with linkified
 CURIEs):
 
-| text        | curie                                           | references                                                                                                           | contributor                                                             |
-|-------------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|
-| PI(3,4,5)P3 | [hgnc:22979](https://bioregistry.io/hgnc:22979) | [pubmed:29623928](https://bioregistry.io/pubmed:29623928), [pubmed:20817957](https://bioregistry.io/pubmed:20817957) | [0000-0003-4423-4370](https://bioregistry.io/orcid:0000-0003-4423-4370) |
+| text        | curie                                           | provenance                                                                                                           | contributor                                                             | language |
+|-------------|-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|----------|
+| PI(3,4,5)P3 | [hgnc:22979](https://bioregistry.io/hgnc:22979) | [pubmed:29623928](https://bioregistry.io/pubmed:29623928), [pubmed:20817957](https://bioregistry.io/pubmed:20817957) | [0000-0003-4423-4370](https://bioregistry.io/orcid:0000-0003-4423-4370) | en       |
 
 ## Known Limitations
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ columns:
    semantic spaces like [`pubmed`](https://bioregistry.io/pubmed),
    [`pmc`](https://bioregistry.io/pmc), [`doi`](https://bioregistry.io/doi))
 7. `contributor` the ORCID identifier of the contributor
-8. `language` the (optional) ISO 2-letter language code. If missing, assumed to be American English.
+8. `date` the optional date when the row was curated in YYYY-MM-DD format
+9. `language` the (optional) ISO 2-letter language code. If missing, assumed to be American English.
+10. `comment` an optional comment
+11. `source` the source of the synonyms, usually `biosynonyms` unless imported from elsewhere
 
 Here's an example of some rows in the synonyms table (with linkified CURIEs):
 

--- a/exports/README.md
+++ b/exports/README.md
@@ -1,0 +1,4 @@
+# Biosynoynms Exports
+
+1. `biosynonyms.ttl` - This is a Turtle (ttl) file format encoding an OWL ontology representation of the synonyms
+   curated in Biosynonyms. It has full (optional) internationalization support.

--- a/exports/biosynonyms.ttl
+++ b/exports/biosynonyms.ttl
@@ -340,6 +340,7 @@ chebi:16618 a owl:Class ;
     owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "phosphatidylinositol (3,4,5) P3"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:date "2022-05-09"^^xsd:date ;
     dcterms:source "biosynonyms" ;
     oboInOwl:hasDbXref pubmed:29695532 .
 ] .
@@ -349,6 +350,7 @@ chebi:16618 a owl:Class ;
     owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "PI(3,4,5)P3"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:date "2022-05-09"^^xsd:date ;
     dcterms:source "biosynonyms" ;
     oboInOwl:hasDbXref pubmed:29623928 ;
     oboInOwl:hasDbXref pubmed:20817957 ;

--- a/exports/biosynonyms.ttl
+++ b/exports/biosynonyms.ttl
@@ -1,0 +1,433 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#> .
+@prefix orcid: <https://orcid.org/> .
+@prefix OMO: <http://purl.obolibrary.org/obo/OMO_> .
+@prefix NCBITaxon: <http://purl.obolibrary.org/obo/NCBITaxon_> .
+@prefix QUALO: <http://purl.obolibrary.org/obo/QUALO_> .
+@prefix go: <http://purl.obolibrary.org/obo/GO_> .
+@prefix eccode: <https://www.ebi.ac.uk/intenz/query?cmd=SearchEC&ec=> .
+@prefix hgnc.genegroup: <https://www.genenames.org/data/genegroup/#!/group/> .
+@prefix cl: <http://purl.obolibrary.org/obo/CL_> .
+@prefix interpro: <https://www.ebi.ac.uk/interpro/entry/InterPro/> .
+@prefix hgnc: <https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/> .
+@prefix pubmed: <https://www.ncbi.nlm.nih.gov/pubmed/> .
+@prefix hp: <http://purl.obolibrary.org/obo/HP_> .
+@prefix complexportal: <https://www.ebi.ac.uk/complexportal/complex/> .
+@prefix sgd: <https://www.yeastgenome.org/locus/> .
+@prefix mesh: <https://meshb.nlm.nih.gov/record/ui?ui=> .
+@prefix symp: <http://purl.obolibrary.org/obo/SYMP_> .
+@prefix chebi: <http://purl.obolibrary.org/obo/CHEBI_> .
+
+<https://w3id.org/biopragmatics/resources/biosynonyms.ttl> a owl:Ontology ;
+    dcterms:title "Biosynonyms in OWL" ;
+    dcterms:description "An ontology representation of community curated synonyms in Biosynonyms" ;
+    dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
+    rdfs:comment "Built by https://github.com/biopragmatics/biosynonyms"^^xsd:string .
+
+
+rdfs:label a owl:AnnotationProperty;
+    rdfs:label "label"^^xsd:string .
+
+oboInOwl:hasSynonym a owl:AnnotationProperty;
+    rdfs:label "has synonym"^^xsd:string .
+
+oboInOwl:hasExactSynonym a owl:AnnotationProperty;
+    rdfs:label "has exact synonym"^^xsd:string .
+
+oboInOwl:hasNarrowSynonym a owl:AnnotationProperty;
+    rdfs:label "has narrow synonym"^^xsd:string .
+
+oboInOwl:hasBroadSynonym a owl:AnnotationProperty;
+    rdfs:label "has broad synonym"^^xsd:string .
+
+oboInOwl:hasRelatedSynonym a owl:AnnotationProperty;
+    rdfs:label "has related synonym"^^xsd:string .
+
+oboInOwl:hasSynonymType a owl:AnnotationProperty;
+    rdfs:label "has synonym type"^^xsd:string .
+
+oboInOwl:hasDbXref a owl:AnnotationProperty;
+    rdfs:label "has database cross-reference"^^xsd:string .
+
+dcterms:contributor a owl:AnnotationProperty;
+    rdfs:label "contributor"^^xsd:string .
+
+dcterms:source a owl:AnnotationProperty;
+    rdfs:label "source"^^xsd:string .
+
+rdfs:seeAlso a owl:AnnotationProperty;
+    rdfs:label "see also"^^xsd:string .
+
+rdfs:comment a owl:AnnotationProperty;
+    rdfs:label "comment"^^xsd:string .
+
+NCBITaxon:9606 a owl:Class ;
+    rdfs:label "Homo sapiens" .
+
+orcid:0000-0003-4423-4370 a NCBITaxon:9606 ;
+    rdfs:label "Charles Tapley Hoyt"@en .    
+
+orcid:0000-0001-9439-5346 a NCBITaxon:9606 ;
+    rdfs:label "Benjamin M. Gyori"@en .
+
+# See new OMO synoynms at 
+# https://github.com/information-artifact-ontology/ontology-metadata/blob/master/src/templates/annotation_properties.tsv    
+
+OMO:0003000 a owl:AnnotationProperty;
+    rdfs:label "abbreviation"^^xsd:string .
+
+OMO:0003001 a owl:AnnotationProperty;
+    rdfs:label "ambiguous synonym"^^xsd:string .
+
+OMO:0003002 a owl:AnnotationProperty;
+    rdfs:label "dubious synonym"^^xsd:string .
+
+OMO:0003003 a owl:AnnotationProperty;
+    rdfs:label "layperson synonym"^^xsd:string .
+
+OMO:0003004 a owl:AnnotationProperty;
+    rdfs:label "plural form"^^xsd:string .
+
+OMO:0003005 a owl:AnnotationProperty;
+    rdfs:label "UK spelling"^^xsd:string .
+
+OMO:0003006 a owl:AnnotationProperty;
+    rdfs:label "misspelling"^^xsd:string .
+
+OMO:0003007 a owl:AnnotationProperty;
+    rdfs:label "misnomer"^^xsd:string .
+
+OMO:0003008 a owl:AnnotationProperty;
+    rdfs:label "previous name"^^xsd:string .
+
+OMO:0003009 a owl:AnnotationProperty;
+    rdfs:label "legal name"^^xsd:string .
+
+OMO:0003010 a owl:AnnotationProperty;
+    rdfs:label "International Nonproprietary Name"^^xsd:string .
+
+OMO:0003011 a owl:AnnotationProperty;
+    rdfs:label "latin term"^^xsd:string .
+
+OMO:0003012 a owl:AnnotationProperty;
+    rdfs:label "acronym"^^xsd:string .    
+
+
+chebi:133726 a owl:Class ;
+    oboInOwl:hasExactSynonym "1,3-dimethylurate"@en ;
+    rdfs:label "1,3-dimethylurate anion" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource chebi:133726 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "1,3-dimethylurate"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+mesh:C000590451 a owl:Class ;
+    oboInOwl:hasExactSynonym "abema"@en ;
+    rdfs:label "abemaciclib" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource mesh:C000590451 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "abema"@en ;
+    dcterms:contributor orcid:0000-0001-9439-5346 ;
+    dcterms:source "biosynonyms" .
+] .
+
+interpro:IPR024162 a owl:Class ;
+    oboInOwl:hasExactSynonym "adaptor protein cbl"@en ;
+    rdfs:label "Adaptor protein Cbl" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource interpro:IPR024162 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "adaptor protein cbl"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+chebi:48432 a owl:Class ;
+    oboInOwl:hasExactSynonym "Angiotensin-2"@en ;
+    rdfs:label "angiotensin II" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource chebi:48432 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "Angiotensin-2"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+eccode:3.6.1.3 a owl:Class ;
+    oboInOwl:hasExactSynonym "ATPase"@en ;
+    rdfs:label "adenosinetriphosphatase" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource eccode:3.6.1.3 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "ATPase"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+hgnc.genegroup:412 a owl:Class ;
+    oboInOwl:hasExactSynonym "ATPase"@en ;
+    rdfs:label "ATPases" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource hgnc.genegroup:412 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "ATPase"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+go:0006915 a owl:Class ;
+    oboInOwl:hasExactSynonym "cell apoptosis"@en ;
+    rdfs:label "apoptotic process" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource go:0006915 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "cell apoptosis"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+symp:0020026 a owl:Class ;
+    oboInOwl:hasExactSynonym "chronic inflammation"@en ;
+    rdfs:label "chronic inflammation" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource symp:0020026 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "chronic inflammation"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+hgnc:5438 a owl:Class ;
+    oboInOwl:hasExactSynonym "IFN-\\u03b3"@en ;
+    oboInOwl:hasExactSynonym "IFN-\u03b3"@en ;
+    rdfs:label "IFNG" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource hgnc:5438 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "IFN-\\u03b3"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource hgnc:5438 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "IFN-\u03b3"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+hgnc:5992 a owl:Class ;
+    oboInOwl:hasExactSynonym "IL-1\\u03b2"@en ;
+    oboInOwl:hasExactSynonym "IL-1\u03b2"@en ;
+    rdfs:label "IL1B" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource hgnc:5992 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "IL-1\\u03b2"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource hgnc:5992 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "IL-1\u03b2"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+cl:0000738 a owl:Class ;
+    oboInOwl:hasExactSynonym "immune cells"@en ;
+    rdfs:label "leukocyte" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource cl:0000738 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "immune cells"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" ;
+    oboInOwl:hasSynonymType OMO:0003004 .
+] .
+
+go:0006954 a owl:Class ;
+    oboInOwl:hasExactSynonym "inflammatory responses"@en ;
+    rdfs:label "inflammatory response" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource go:0006954 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "inflammatory responses"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" ;
+    oboInOwl:hasSynonymType OMO:0003004 .
+] .
+
+hp:0002180 a owl:Class ;
+    oboInOwl:hasExactSynonym "neurodegeneration"@en ;
+    rdfs:label "Neurodegeneration" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource hp:0002180 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "neurodegeneration"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+hp:0033429 a owl:Class ;
+    oboInOwl:hasExactSynonym "neuroinflammation"@en ;
+    rdfs:label "Neuroinflammation" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource hp:0033429 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "neuroinflammation"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+complexportal:CPX-4141 a owl:Class ;
+    oboInOwl:hasExactSynonym "NLRP3 inflammasome"@en ;
+    rdfs:label "NLRP3 inflammasome" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource complexportal:CPX-4141 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "NLRP3 inflammasome"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+chebi:16618 a owl:Class ;
+    oboInOwl:hasExactSynonym "phosphatidylinositol (3,4,5) P3"@en ;
+    oboInOwl:hasExactSynonym "PI(3,4,5)P3"@en ;
+    rdfs:label "1-phosphatidyl-1D-myo-inositol 3,4,5-trisphosphate" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource chebi:16618 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "phosphatidylinositol (3,4,5) P3"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" ;
+    oboInOwl:hasDbXref pubmed:29695532 .
+] .
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource chebi:16618 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "PI(3,4,5)P3"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" ;
+    oboInOwl:hasDbXref pubmed:29623928 ;
+    oboInOwl:hasDbXref pubmed:20817957 ;
+    oboInOwl:hasDbXref pubmed:18931680 ;
+    oboInOwl:hasDbXref pubmed:28443090 .
+] .
+
+hgnc:11892 a owl:Class ;
+    oboInOwl:hasExactSynonym "TNF-\\u03b1"@en ;
+    oboInOwl:hasExactSynonym "TNF-\u03b1"@en ;
+    rdfs:label "TNF" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource hgnc:11892 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "TNF-\\u03b1"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" ;
+    rdfs:comment "for situations when the escaping in the text is incorrect, and the unicode character string for beta is raw" .
+] .
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource hgnc:11892 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "TNF-\u03b1"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+sgd:S000000019 a owl:Class ;
+    oboInOwl:hasExactSynonym "YAL021C"@en ;
+    rdfs:label "CCR4" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource sgd:S000000019 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "YAL021C"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+sgd:S000002319 a owl:Class ;
+    oboInOwl:hasExactSynonym "YDL160C"@en ;
+    rdfs:label "DHH1" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource sgd:S000002319 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "YDL160C"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+sgd:S000003090 a owl:Class ;
+    oboInOwl:hasExactSynonym "YGL122C"@en ;
+    rdfs:label "NAB2" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource sgd:S000003090 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "YGL122C"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .
+
+sgd:S000005153 a owl:Class ;
+    oboInOwl:hasExactSynonym "YNL209W"@en ;
+    rdfs:label "SSB2" .
+
+[ 
+    a owl:Axiom ;
+    owl:annotatedSource sgd:S000005153 ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedTarget "YNL209W"@en ;
+    dcterms:contributor orcid:0000-0003-4423-4370 ;
+    dcterms:source "biosynonyms" .
+] .

--- a/exports/biosynonyms.ttl
+++ b/exports/biosynonyms.ttl
@@ -1,24 +1,23 @@
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#> .
-@prefix orcid: <https://orcid.org/> .
-@prefix OMO: <http://purl.obolibrary.org/obo/OMO_> .
-@prefix NCBITaxon: <http://purl.obolibrary.org/obo/NCBITaxon_> .
-@prefix QUALO: <http://purl.obolibrary.org/obo/QUALO_> .
-@prefix go: <http://purl.obolibrary.org/obo/GO_> .
-@prefix eccode: <https://www.ebi.ac.uk/intenz/query?cmd=SearchEC&ec=> .
-@prefix hgnc.genegroup: <https://www.genenames.org/data/genegroup/#!/group/> .
-@prefix cl: <http://purl.obolibrary.org/obo/CL_> .
-@prefix interpro: <https://www.ebi.ac.uk/interpro/entry/InterPro/> .
-@prefix hgnc: <https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/> .
-@prefix pubmed: <https://www.ncbi.nlm.nih.gov/pubmed/> .
-@prefix hp: <http://purl.obolibrary.org/obo/HP_> .
-@prefix complexportal: <https://www.ebi.ac.uk/complexportal/complex/> .
-@prefix sgd: <https://www.yeastgenome.org/locus/> .
-@prefix mesh: <https://meshb.nlm.nih.gov/record/ui?ui=> .
-@prefix symp: <http://purl.obolibrary.org/obo/SYMP_> .
 @prefix chebi: <http://purl.obolibrary.org/obo/CHEBI_> .
+@prefix cl: <http://purl.obolibrary.org/obo/CL_> .
+@prefix complexportal: <https://www.ebi.ac.uk/complexportal/complex/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix eccode: <https://www.ebi.ac.uk/intenz/query?cmd=SearchEC&ec=> .
+@prefix go: <http://purl.obolibrary.org/obo/GO_> .
+@prefix hgnc: <https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/> .
+@prefix hgnc.genegroup: <https://www.genenames.org/data/genegroup/#!/group/> .
+@prefix hp: <http://purl.obolibrary.org/obo/HP_> .
+@prefix interpro: <http://purl.obolibrary.org/obo/IPR_$1> .
+@prefix mesh: <https://meshb.nlm.nih.gov/record/ui?ui=> .
+@prefix NCBITaxon: <http://purl.obolibrary.org/obo/NCBITaxon_> .
+@prefix oboInOwl: <http://www.geneontology.org/formats/oboInOwl#> .
+@prefix OMO: <http://purl.obolibrary.org/obo/OMO_> .
+@prefix orcid: <https://orcid.org/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix pubmed: <https://www.ncbi.nlm.nih.gov/pubmed/> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sgd: <https://www.yeastgenome.org/locus/> .
+@prefix symp: <http://purl.obolibrary.org/obo/SYMP_> .
 
 <https://w3id.org/biopragmatics/resources/biosynonyms.ttl> a owl:Ontology ;
     dcterms:title "Biosynonyms in OWL" ;
@@ -67,13 +66,13 @@ NCBITaxon:9606 a owl:Class ;
     rdfs:label "Homo sapiens" .
 
 orcid:0000-0003-4423-4370 a NCBITaxon:9606 ;
-    rdfs:label "Charles Tapley Hoyt"@en .    
+    rdfs:label "Charles Tapley Hoyt"@en .
 
 orcid:0000-0001-9439-5346 a NCBITaxon:9606 ;
     rdfs:label "Benjamin M. Gyori"@en .
 
-# See new OMO synoynms at 
-# https://github.com/information-artifact-ontology/ontology-metadata/blob/master/src/templates/annotation_properties.tsv    
+# See new OMO synonyms at
+# https://github.com/information-artifact-ontology/ontology-metadata/blob/master/src/templates/annotation_properties.tsv
 
 OMO:0003000 a owl:AnnotationProperty;
     rdfs:label "abbreviation"^^xsd:string .
@@ -112,165 +111,165 @@ OMO:0003011 a owl:AnnotationProperty;
     rdfs:label "latin term"^^xsd:string .
 
 OMO:0003012 a owl:AnnotationProperty;
-    rdfs:label "acronym"^^xsd:string .    
+    rdfs:label "acronym"^^xsd:string .
 
 
 chebi:133726 a owl:Class ;
-    oboInOwl:hasExactSynonym "1,3-dimethylurate"@en ;
+    oboInOwl:hasSynonym "1,3-dimethylurate"@en ;
     rdfs:label "1,3-dimethylurate anion" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource chebi:133726 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "1,3-dimethylurate"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 mesh:C000590451 a owl:Class ;
-    oboInOwl:hasExactSynonym "abema"@en ;
+    oboInOwl:hasSynonym "abema"@en ;
     rdfs:label "abemaciclib" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource mesh:C000590451 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "abema"@en ;
     dcterms:contributor orcid:0000-0001-9439-5346 ;
     dcterms:source "biosynonyms" .
 ] .
 
 interpro:IPR024162 a owl:Class ;
-    oboInOwl:hasExactSynonym "adaptor protein cbl"@en ;
+    oboInOwl:hasSynonym "adaptor protein cbl"@en ;
     rdfs:label "Adaptor protein Cbl" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource interpro:IPR024162 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "adaptor protein cbl"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 chebi:48432 a owl:Class ;
-    oboInOwl:hasExactSynonym "Angiotensin-2"@en ;
+    oboInOwl:hasSynonym "Angiotensin-2"@en ;
     rdfs:label "angiotensin II" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource chebi:48432 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "Angiotensin-2"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 eccode:3.6.1.3 a owl:Class ;
-    oboInOwl:hasExactSynonym "ATPase"@en ;
+    oboInOwl:hasSynonym "ATPase"@en ;
     rdfs:label "adenosinetriphosphatase" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource eccode:3.6.1.3 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "ATPase"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 hgnc.genegroup:412 a owl:Class ;
-    oboInOwl:hasExactSynonym "ATPase"@en ;
+    oboInOwl:hasSynonym "ATPase"@en ;
     rdfs:label "ATPases" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource hgnc.genegroup:412 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "ATPase"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 go:0006915 a owl:Class ;
-    oboInOwl:hasExactSynonym "cell apoptosis"@en ;
+    oboInOwl:hasSynonym "cell apoptosis"@en ;
     rdfs:label "apoptotic process" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource go:0006915 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "cell apoptosis"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 symp:0020026 a owl:Class ;
-    oboInOwl:hasExactSynonym "chronic inflammation"@en ;
+    oboInOwl:hasSynonym "chronic inflammation"@en ;
     rdfs:label "chronic inflammation" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource symp:0020026 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "chronic inflammation"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 hgnc:5438 a owl:Class ;
-    oboInOwl:hasExactSynonym "IFN-\\u03b3"@en ;
-    oboInOwl:hasExactSynonym "IFN-\u03b3"@en ;
+    oboInOwl:hasSynonym "IFN-\\u03b3"@en ;
+    oboInOwl:hasSynonym "IFN-\u03b3"@en ;
     rdfs:label "IFNG" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource hgnc:5438 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "IFN-\\u03b3"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource hgnc:5438 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "IFN-\u03b3"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 hgnc:5992 a owl:Class ;
-    oboInOwl:hasExactSynonym "IL-1\\u03b2"@en ;
-    oboInOwl:hasExactSynonym "IL-1\u03b2"@en ;
+    oboInOwl:hasSynonym "IL-1\\u03b2"@en ;
+    oboInOwl:hasSynonym "IL-1\u03b2"@en ;
     rdfs:label "IL1B" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource hgnc:5992 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "IL-1\\u03b2"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource hgnc:5992 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "IL-1\u03b2"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 cl:0000738 a owl:Class ;
-    oboInOwl:hasExactSynonym "immune cells"@en ;
+    oboInOwl:hasSynonym "immune cells"@en ;
     rdfs:label "leukocyte" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource cl:0000738 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "immune cells"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" ;
@@ -278,13 +277,13 @@ cl:0000738 a owl:Class ;
 ] .
 
 go:0006954 a owl:Class ;
-    oboInOwl:hasExactSynonym "inflammatory responses"@en ;
+    oboInOwl:hasSynonym "inflammatory responses"@en ;
     rdfs:label "inflammatory response" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource go:0006954 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "inflammatory responses"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" ;
@@ -292,62 +291,62 @@ go:0006954 a owl:Class ;
 ] .
 
 hp:0002180 a owl:Class ;
-    oboInOwl:hasExactSynonym "neurodegeneration"@en ;
+    oboInOwl:hasSynonym "neurodegeneration"@en ;
     rdfs:label "Neurodegeneration" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource hp:0002180 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "neurodegeneration"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 hp:0033429 a owl:Class ;
-    oboInOwl:hasExactSynonym "neuroinflammation"@en ;
+    oboInOwl:hasSynonym "neuroinflammation"@en ;
     rdfs:label "Neuroinflammation" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource hp:0033429 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "neuroinflammation"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 complexportal:CPX-4141 a owl:Class ;
-    oboInOwl:hasExactSynonym "NLRP3 inflammasome"@en ;
+    oboInOwl:hasSynonym "NLRP3 inflammasome"@en ;
     rdfs:label "NLRP3 inflammasome" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource complexportal:CPX-4141 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "NLRP3 inflammasome"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 chebi:16618 a owl:Class ;
-    oboInOwl:hasExactSynonym "phosphatidylinositol (3,4,5) P3"@en ;
-    oboInOwl:hasExactSynonym "PI(3,4,5)P3"@en ;
+    oboInOwl:hasSynonym "phosphatidylinositol (3,4,5) P3"@en ;
+    oboInOwl:hasSynonym "PI(3,4,5)P3"@en ;
     rdfs:label "1-phosphatidyl-1D-myo-inositol 3,4,5-trisphosphate" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource chebi:16618 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "phosphatidylinositol (3,4,5) P3"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" ;
     oboInOwl:hasDbXref pubmed:29695532 .
 ] .
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource chebi:16618 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "PI(3,4,5)P3"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" ;
@@ -358,75 +357,75 @@ chebi:16618 a owl:Class ;
 ] .
 
 hgnc:11892 a owl:Class ;
-    oboInOwl:hasExactSynonym "TNF-\\u03b1"@en ;
-    oboInOwl:hasExactSynonym "TNF-\u03b1"@en ;
+    oboInOwl:hasSynonym "TNF-\\u03b1"@en ;
+    oboInOwl:hasSynonym "TNF-\u03b1"@en ;
     rdfs:label "TNF" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource hgnc:11892 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "TNF-\\u03b1"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" ;
     rdfs:comment "for situations when the escaping in the text is incorrect, and the unicode character string for beta is raw" .
 ] .
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource hgnc:11892 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "TNF-\u03b1"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 sgd:S000000019 a owl:Class ;
-    oboInOwl:hasExactSynonym "YAL021C"@en ;
+    oboInOwl:hasSynonym "YAL021C"@en ;
     rdfs:label "CCR4" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource sgd:S000000019 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "YAL021C"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 sgd:S000002319 a owl:Class ;
-    oboInOwl:hasExactSynonym "YDL160C"@en ;
+    oboInOwl:hasSynonym "YDL160C"@en ;
     rdfs:label "DHH1" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource sgd:S000002319 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "YDL160C"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 sgd:S000003090 a owl:Class ;
-    oboInOwl:hasExactSynonym "YGL122C"@en ;
+    oboInOwl:hasSynonym "YGL122C"@en ;
     rdfs:label "NAB2" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource sgd:S000003090 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "YGL122C"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 sgd:S000005153 a owl:Class ;
-    oboInOwl:hasExactSynonym "YNL209W"@en ;
+    oboInOwl:hasSynonym "YNL209W"@en ;
     rdfs:label "SSB2" .
 
-[ 
+[
     a owl:Axiom ;
     owl:annotatedSource sgd:S000005153 ;
-    owl:annotatedProperty oboInOwl:hasExactSynonym ;
+    owl:annotatedProperty oboInOwl:hasSynonym ;
     owl:annotatedTarget "YNL209W"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .

--- a/exports/biosynonyms.ttl
+++ b/exports/biosynonyms.ttl
@@ -1,3 +1,4 @@
+@prefix BFO: <http://purl.obolibrary.org/obo/BFO_> .
 @prefix chebi: <http://purl.obolibrary.org/obo/CHEBI_> .
 @prefix cl: <http://purl.obolibrary.org/obo/CL_> .
 @prefix complexportal: <https://www.ebi.ac.uk/complexportal/complex/> .
@@ -17,6 +18,7 @@
 @prefix pubmed: <https://www.ncbi.nlm.nih.gov/pubmed/> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix sgd: <https://www.yeastgenome.org/locus/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix symp: <http://purl.obolibrary.org/obo/SYMP_> .
 
 <https://w3id.org/biopragmatics/resources/biosynonyms.ttl> a owl:Ontology ;
@@ -26,8 +28,9 @@
     rdfs:comment "Built by https://github.com/biopragmatics/biosynonyms"^^xsd:string .
 
 
-rdfs:label a owl:AnnotationProperty;
-    rdfs:label "label"^^xsd:string .
+rdfs:label   a owl:AnnotationProperty; rdfs:label "label"^^xsd:string .
+rdfs:seeAlso a owl:AnnotationProperty; rdfs:label "see also"^^xsd:string .
+rdfs:comment a owl:AnnotationProperty; rdfs:label "comment"^^xsd:string .
 
 oboInOwl:hasSynonym a owl:AnnotationProperty;
     rdfs:label "has synonym"^^xsd:string .
@@ -50,17 +53,14 @@ oboInOwl:hasSynonymType a owl:AnnotationProperty;
 oboInOwl:hasDbXref a owl:AnnotationProperty;
     rdfs:label "has database cross-reference"^^xsd:string .
 
-dcterms:contributor a owl:AnnotationProperty;
-    rdfs:label "contributor"^^xsd:string .
+skos:exactMatch a owl:AnnotationProperty; rdfs:label "exact match"^^xsd:string .
 
-dcterms:source a owl:AnnotationProperty;
-    rdfs:label "source"^^xsd:string .
+dcterms:contributor a owl:AnnotationProperty; rdfs:label "contributor"^^xsd:string .
+dcterms:source      a owl:AnnotationProperty; rdfs:label "source"^^xsd:string .
+dcterms:license     a owl:AnnotationProperty; rdfs:label "license"^^xsd:string .
+dcterms:description a owl:AnnotationProperty; rdfs:label "description"^^xsd:string .
 
-rdfs:seeAlso a owl:AnnotationProperty;
-    rdfs:label "see also"^^xsd:string .
-
-rdfs:comment a owl:AnnotationProperty;
-    rdfs:label "comment"^^xsd:string .
+BFO:0000051 a owl:ObjectProperty; rdfs:label "has part"^^xsd:string .
 
 NCBITaxon:9606 a owl:Class ;
     rdfs:label "Homo sapiens" .
@@ -115,118 +115,118 @@ OMO:0003012 a owl:AnnotationProperty;
 
 
 chebi:133726 a owl:Class ;
-    oboInOwl:hasSynonym "1,3-dimethylurate"@en ;
+    oboInOwl:hasExactSynonym "1,3-dimethylurate"@en ;
     rdfs:label "1,3-dimethylurate anion" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource chebi:133726 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "1,3-dimethylurate"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 mesh:C000590451 a owl:Class ;
-    oboInOwl:hasSynonym "abema"@en ;
+    oboInOwl:hasExactSynonym "abema"@en ;
     rdfs:label "abemaciclib" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource mesh:C000590451 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "abema"@en ;
     dcterms:contributor orcid:0000-0001-9439-5346 ;
     dcterms:source "biosynonyms" .
 ] .
 
 interpro:IPR024162 a owl:Class ;
-    oboInOwl:hasSynonym "adaptor protein cbl"@en ;
+    oboInOwl:hasExactSynonym "adaptor protein cbl"@en ;
     rdfs:label "Adaptor protein Cbl" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource interpro:IPR024162 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "adaptor protein cbl"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 chebi:48432 a owl:Class ;
-    oboInOwl:hasSynonym "Angiotensin-2"@en ;
+    oboInOwl:hasExactSynonym "Angiotensin-2"@en ;
     rdfs:label "angiotensin II" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource chebi:48432 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "Angiotensin-2"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 eccode:3.6.1.3 a owl:Class ;
-    oboInOwl:hasSynonym "ATPase"@en ;
+    oboInOwl:hasExactSynonym "ATPase"@en ;
     rdfs:label "adenosinetriphosphatase" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource eccode:3.6.1.3 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "ATPase"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 hgnc.genegroup:412 a owl:Class ;
-    oboInOwl:hasSynonym "ATPase"@en ;
+    oboInOwl:hasExactSynonym "ATPase"@en ;
     rdfs:label "ATPases" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource hgnc.genegroup:412 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "ATPase"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 go:0006915 a owl:Class ;
-    oboInOwl:hasSynonym "cell apoptosis"@en ;
+    oboInOwl:hasExactSynonym "cell apoptosis"@en ;
     rdfs:label "apoptotic process" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource go:0006915 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "cell apoptosis"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 symp:0020026 a owl:Class ;
-    oboInOwl:hasSynonym "chronic inflammation"@en ;
+    oboInOwl:hasExactSynonym "chronic inflammation"@en ;
     rdfs:label "chronic inflammation" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource symp:0020026 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "chronic inflammation"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 hgnc:5438 a owl:Class ;
-    oboInOwl:hasSynonym "IFN-\\u03b3"@en ;
-    oboInOwl:hasSynonym "IFN-\u03b3"@en ;
+    oboInOwl:hasExactSynonym "IFN-\\u03b3"@en ;
+    oboInOwl:hasExactSynonym "IFN-\u03b3"@en ;
     rdfs:label "IFNG" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource hgnc:5438 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "IFN-\\u03b3"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
@@ -234,21 +234,21 @@ hgnc:5438 a owl:Class ;
 [
     a owl:Axiom ;
     owl:annotatedSource hgnc:5438 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "IFN-\u03b3"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 hgnc:5992 a owl:Class ;
-    oboInOwl:hasSynonym "IL-1\\u03b2"@en ;
-    oboInOwl:hasSynonym "IL-1\u03b2"@en ;
+    oboInOwl:hasExactSynonym "IL-1\\u03b2"@en ;
+    oboInOwl:hasExactSynonym "IL-1\u03b2"@en ;
     rdfs:label "IL1B" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource hgnc:5992 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "IL-1\\u03b2"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
@@ -256,20 +256,20 @@ hgnc:5992 a owl:Class ;
 [
     a owl:Axiom ;
     owl:annotatedSource hgnc:5992 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "IL-1\u03b2"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 cl:0000738 a owl:Class ;
-    oboInOwl:hasSynonym "immune cells"@en ;
+    oboInOwl:hasExactSynonym "immune cells"@en ;
     rdfs:label "leukocyte" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource cl:0000738 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "immune cells"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" ;
@@ -277,13 +277,13 @@ cl:0000738 a owl:Class ;
 ] .
 
 go:0006954 a owl:Class ;
-    oboInOwl:hasSynonym "inflammatory responses"@en ;
+    oboInOwl:hasExactSynonym "inflammatory responses"@en ;
     rdfs:label "inflammatory response" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource go:0006954 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "inflammatory responses"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" ;
@@ -291,53 +291,53 @@ go:0006954 a owl:Class ;
 ] .
 
 hp:0002180 a owl:Class ;
-    oboInOwl:hasSynonym "neurodegeneration"@en ;
+    oboInOwl:hasExactSynonym "neurodegeneration"@en ;
     rdfs:label "Neurodegeneration" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource hp:0002180 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "neurodegeneration"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 hp:0033429 a owl:Class ;
-    oboInOwl:hasSynonym "neuroinflammation"@en ;
+    oboInOwl:hasExactSynonym "neuroinflammation"@en ;
     rdfs:label "Neuroinflammation" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource hp:0033429 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "neuroinflammation"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 complexportal:CPX-4141 a owl:Class ;
-    oboInOwl:hasSynonym "NLRP3 inflammasome"@en ;
+    oboInOwl:hasExactSynonym "NLRP3 inflammasome"@en ;
     rdfs:label "NLRP3 inflammasome" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource complexportal:CPX-4141 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "NLRP3 inflammasome"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 chebi:16618 a owl:Class ;
-    oboInOwl:hasSynonym "phosphatidylinositol (3,4,5) P3"@en ;
-    oboInOwl:hasSynonym "PI(3,4,5)P3"@en ;
+    oboInOwl:hasExactSynonym "phosphatidylinositol (3,4,5) P3"@en ;
+    oboInOwl:hasExactSynonym "PI(3,4,5)P3"@en ;
     rdfs:label "1-phosphatidyl-1D-myo-inositol 3,4,5-trisphosphate" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource chebi:16618 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "phosphatidylinositol (3,4,5) P3"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" ;
@@ -346,7 +346,7 @@ chebi:16618 a owl:Class ;
 [
     a owl:Axiom ;
     owl:annotatedSource chebi:16618 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "PI(3,4,5)P3"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" ;
@@ -357,14 +357,14 @@ chebi:16618 a owl:Class ;
 ] .
 
 hgnc:11892 a owl:Class ;
-    oboInOwl:hasSynonym "TNF-\\u03b1"@en ;
-    oboInOwl:hasSynonym "TNF-\u03b1"@en ;
+    oboInOwl:hasExactSynonym "TNF-\\u03b1"@en ;
+    oboInOwl:hasExactSynonym "TNF-\u03b1"@en ;
     rdfs:label "TNF" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource hgnc:11892 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "TNF-\\u03b1"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" ;
@@ -373,59 +373,59 @@ hgnc:11892 a owl:Class ;
 [
     a owl:Axiom ;
     owl:annotatedSource hgnc:11892 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "TNF-\u03b1"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 sgd:S000000019 a owl:Class ;
-    oboInOwl:hasSynonym "YAL021C"@en ;
+    oboInOwl:hasExactSynonym "YAL021C"@en ;
     rdfs:label "CCR4" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource sgd:S000000019 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "YAL021C"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 sgd:S000002319 a owl:Class ;
-    oboInOwl:hasSynonym "YDL160C"@en ;
+    oboInOwl:hasExactSynonym "YDL160C"@en ;
     rdfs:label "DHH1" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource sgd:S000002319 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "YDL160C"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 sgd:S000003090 a owl:Class ;
-    oboInOwl:hasSynonym "YGL122C"@en ;
+    oboInOwl:hasExactSynonym "YGL122C"@en ;
     rdfs:label "NAB2" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource sgd:S000003090 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "YGL122C"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .
 ] .
 
 sgd:S000005153 a owl:Class ;
-    oboInOwl:hasSynonym "YNL209W"@en ;
+    oboInOwl:hasExactSynonym "YNL209W"@en ;
     rdfs:label "SSB2" .
 
 [
     a owl:Axiom ;
     owl:annotatedSource sgd:S000005153 ;
-    owl:annotatedProperty oboInOwl:hasSynonym ;
+    owl:annotatedProperty oboInOwl:hasExactSynonym ;
     owl:annotatedTarget "YNL209W"@en ;
     dcterms:contributor orcid:0000-0003-4423-4370 ;
     dcterms:source "biosynonyms" .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 # See https://setuptools.readthedocs.io/en/latest/build_meta.html
 [build-system]
 requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta:__legacy__"
+build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 100
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+target-version = ["py39", "py310", "py311", "py312"]
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.black]
 line-length = 100
-target-version = ["py37", "py38", "py39", "py310"]
+target-version = ["py38", "py39", "py310", "py311", "py312"]
 
 [tool.isort]
 profile = "black"

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -56,7 +55,6 @@ install_requires =
     pydantic>=2.0
     pydantic_extra_types
     pycountry
-    numbers-parser
 
 zip_safe = false
 include_package_data = True
@@ -71,6 +69,8 @@ package_dir =
 where = src
 
 [options.extras_require]
+numbers =
+    numbers-parser
 tests =
     coverage
     pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,10 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
+    Framework :: Pydantic
+    Framework :: Pydantic :: 2
 keywords =
     databases
     biological databases
@@ -50,7 +53,9 @@ install_requires =
     curies
     bioregistry
     pandas
-    pydantic
+    pydantic>=2.0
+    pydantic_extra_types
+    pycountry
 
 zip_safe = false
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,7 @@ install_requires =
     pydantic>=2.0
     pydantic_extra_types
     pycountry
+    numbers-parser
 
 zip_safe = false
 include_package_data = True

--- a/src/biosynonyms/__init__.py
+++ b/src/biosynonyms/__init__.py
@@ -2,9 +2,9 @@
 
 from .resources import (
     Synonym,
+    get_gilda_terms,
     get_negative_synonyms,
     get_positive_synonyms,
-    iter_gilda_terms,
     load_unentities,
     parse_synonyms,
 )
@@ -14,6 +14,6 @@ __all__ = [
     "get_positive_synonyms",
     "get_negative_synonyms",
     "parse_synonyms",
-    "iter_gilda_terms",
+    "get_gilda_terms",
     "load_unentities",
 ]

--- a/src/biosynonyms/__init__.py
+++ b/src/biosynonyms/__init__.py
@@ -2,9 +2,9 @@
 
 from .resources import (
     Synonym,
-    get_gilda_terms,
     get_negative_synonyms,
     get_positive_synonyms,
+    iter_gilda_terms,
     load_unentities,
     parse_synonyms,
 )
@@ -14,6 +14,6 @@ __all__ = [
     "get_positive_synonyms",
     "get_negative_synonyms",
     "parse_synonyms",
-    "get_gilda_terms",
+    "iter_gilda_terms",
     "load_unentities",
 ]

--- a/src/biosynonyms/generate_owl.py
+++ b/src/biosynonyms/generate_owl.py
@@ -197,6 +197,8 @@ def _write_owl_rdf(
             axiom_parts = [
                 f"dcterms:contributor {synonym.contributor.curie}",
             ]
+            if synonym.date:
+                axiom_parts.append(f'dcterms:date "{synonym.date_str}"^^xsd:date')
             if synonym.source:
                 axiom_parts.append(f'dcterms:source "{_clean_str(synonym.source)}"')
             if synonym.type:

--- a/src/biosynonyms/generate_owl.py
+++ b/src/biosynonyms/generate_owl.py
@@ -11,7 +11,7 @@ from curies import Reference
 from tqdm import tqdm
 
 from biosynonyms import Synonym, get_positive_synonyms
-from biosynonyms.resources import _clean_str, parse_synonyms
+from biosynonyms.resources import _clean_str
 
 HERE = Path(__file__).parent.resolve()
 EXPORT = HERE.parent.parent.joinpath("exports")
@@ -245,113 +245,9 @@ def get_remote_curie_map(
     return {Reference.from_curie(curie): value for curie, value in df[["curie", key]].values}
 
 
-def _main() -> None:
-    import pandas as pd
-
-    """
-    See:
-    - https://docs.google.com/spreadsheets/d/1xW5VcBIjnDHDxVuEEMgdN0-5vnd7g7pKWbpqglx2fb8/edit?gid=0#gid=0
-    - https://github.com/cthoyt/orcid_downloader/blob/main/src/orcid_downloader/standardize.py
-    """
-
-    metadata = dedent(
-        """\
-    <https://purl.obolibrary.org/obo/qualo.owl> a owl:Ontology ;
-        dcterms:title "Qualification Ontology" ;
-        dcterms:description "An ontology representation qualifications, such as academic degrees" ;
-        dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
-        rdfs:comment "Built by https://github.com/biopragmatics/biosynonyms"^^xsd:string ;
-        dcterms:contributor orcid:0000-0003-4423-4370 .
-
-    PATO:0000001 rdfs:label "quality" .
-
-    DISCO:0000001 a owl:Class ; rdfs:label "academic discipline" .
-
-    QUALO:1000001 a owl:AnnotationProperty;
-        rdfs:label "example holder"^^xsd:string ;
-        rdfs:range NCBITaxon:9606 ;
-        rdfs:domain QUALO:0000001 .
-
-    QUALO:1000002 a owl:ObjectProperty;
-        rdfs:label "for discipline"^^xsd:string ;
-        rdfs:range DISCO:0000001 ;
-        rdfs:domain QUALO:0000021 .
-    """
-    )
-    qualo_base = (
-        "https://docs.google.com/spreadsheets/d/e/2PACX-1vTLjgYCVw6wY8mYMcZJY4KSY5"
-        "xyLWYHSaStOUfoonQvsSU_nRyzYiRJ8pYsfF7Zid5jERB08s89bdt0/pub?single=true&output=tsv"
-    )
-    names_url = f"{qualo_base}&gid=0"
-    synonyms_url = f"{qualo_base}&gid=1557592961"
-
-    df = pd.read_csv(names_url, sep="\t")
-    df["reference"] = df["curie"].map(Reference.from_curie, na_action="ignore")
-
-    names = dict(df[["reference", "label"]].values)
-    parents_1 = dict(df[["reference", "parent_1"]].values)
-    parents_2 = dict(df[["reference", "parent_2"]].values)
-
-    synonyms = parse_synonyms(synonyms_url, names=names)
-    qualo_path = EXPORT.joinpath("qualo_synonyms.ttl")
-    with open(qualo_path, "w") as file:
-        _write_owl_rdf(
-            synonyms,
-            file,
-            prefix_map={
-                "QUALO": "http://purl.obolibrary.org/obo/QUALO_",
-                "DISCO": "http://purl.obolibrary.org/obo/DISCO_",
-                "PATO": "http://purl.obolibrary.org/obo/PATO_",
-                "EDAM": "http://edamontology.org/topic_",
-            },
-            metadata=metadata,
-        )
-        for k, v in parents_1.items():
-            if not k:
-                continue
-            if v and pd.notna(v):
-                file.write(
-                    f'{k.curie} rdfs:subClassOf {v} ; rdfs:label "{_clean_str(names[k])}" .\n'
-                )
-            if k in parents_2 and pd.notna(parents_2[k]):
-                file.write(f"{k.curie} rdfs:subClassOf {parents_2[k]} .\n")
-
-        for k, example_curie, example_label in df[["reference", "example", "example_label"]].values:
-            if not example_curie or pd.isna(example_label):
-                continue
-            # this ORCID profile is evidence for the existence of this degree
-            file.write(f"{k.curie} oboInOwl:hasDbXref {example_curie} .\n")
-            file.write(
-                f'{example_curie} a NCBITaxon:9606; rdfs:label "{_clean_str(example_label)}" .\n'
-            )
-
-        for k, wikidata in df[["reference", "wikidata"]].values:
-            if not wikidata or pd.isna(wikidata):
-                continue
-            wikidata = wikidata.removeprefix("https://www.wikidata.org/wiki/")
-            file.write(f"{k.curie} skos:exactMatch {wikidata} .\n")
-
-        for k, discipline_curie, discipline_label in df[
-            ["reference", "discipline", "discipline_label"]
-        ].values:
-            if not discipline_curie or pd.isna(discipline_curie):
-                continue
-            file.write(
-                f'{k.curie} rdfs:subClassOf {_restriction("QUALO:1000002", discipline_curie)} .\n'
-            )
-            file.write(
-                f'{discipline_curie} a owl:Class; rdfs:label "{_clean_str(discipline_label)}" .\n'
-            )
-
-    # write_owl_rdf()
-
-
 def _restriction(prop: str, target: str) -> str:
     return f"[ a owl:Restriction ; owl:onProperty {prop} ; owl:someValuesFrom {target} ]"
 
 
 if __name__ == "__main__":
-    _main()
-
-    # import bioontologies.robot
-    # bioontologies.robot.convert(TTL_PATH, OWL_PATH)
+    write_owl_rdf()

--- a/src/biosynonyms/generate_owl.py
+++ b/src/biosynonyms/generate_owl.py
@@ -145,7 +145,7 @@ def _write_owl_rdf(
     synonyms: list[Synonym],
     file: TextIO,
     *,
-    metadata: str | None = None,
+    metadata: Optional[str] = None,
     prefix_map: Optional[Dict[str, str]] = None,
 ) -> None:
     dd = defaultdict(list)

--- a/src/biosynonyms/generate_owl.py
+++ b/src/biosynonyms/generate_owl.py
@@ -18,7 +18,6 @@ EXPORT = HERE.parent.parent.joinpath("exports")
 EXPORT.mkdir(exist_ok=True)
 
 TTL_PATH = EXPORT.joinpath("biosynonyms.ttl")
-OWL_PATH = EXPORT.joinpath("biosynoynms.owl")
 URI = "https://w3id.org/biopragmatics/resources/biosynonyms.ttl"
 
 METADATA = f"""\
@@ -233,20 +232,6 @@ def _write_owl_rdf(
             file.write("\n")
         for axiom in axiom_strs:
             file.write(dedent(axiom))
-
-
-def get_remote_curie_map(
-    path: Union[str, Path], key: str = "label", delimiter: Optional[str] = None
-) -> Mapping[Reference, str]:
-    """Get a one-to-one data column from a TSV for CURIEs."""
-    import pandas as pd
-
-    df = pd.read_csv(path, sep=delimiter or "\t")
-    return {Reference.from_curie(curie): value for curie, value in df[["curie", key]].values}
-
-
-def _restriction(prop: str, target: str) -> str:
-    return f"[ a owl:Restriction ; owl:onProperty {prop} ; owl:someValuesFrom {target} ]"
 
 
 if __name__ == "__main__":

--- a/src/biosynonyms/generate_owl.py
+++ b/src/biosynonyms/generate_owl.py
@@ -4,10 +4,9 @@ import gzip
 from collections import ChainMap, defaultdict
 from pathlib import Path
 from textwrap import dedent
-from typing import Dict, Mapping, Optional, TextIO, Union
+from typing import Dict, Optional, TextIO
 
 import bioregistry
-from curies import Reference
 from tqdm import tqdm
 
 from biosynonyms import Synonym, get_positive_synonyms

--- a/src/biosynonyms/generate_owl.py
+++ b/src/biosynonyms/generate_owl.py
@@ -1,0 +1,262 @@
+"""Generate OWL from the positive synonyms."""
+
+import gzip
+from collections import defaultdict
+from pathlib import Path
+from textwrap import dedent
+from typing import Mapping, Optional, TextIO, Union
+
+import bioregistry
+from curies import Reference
+from tqdm import tqdm
+
+from biosynonyms import Synonym, get_positive_synonyms
+from biosynonyms.resources import _clean_str, parse_synonyms
+
+HERE = Path(__file__).parent.resolve()
+EXPORT = HERE.parent.parent.joinpath("exports")
+EXPORT.mkdir(exist_ok=True)
+
+TTL_PATH = EXPORT.joinpath("biosynonyms.ttl")
+OWL_PATH = EXPORT.joinpath("biosynoynms.owl")
+URI = "https://w3id.org/biopragmatics/resources/biosynonyms.ttl"
+
+METADATA = f"""\
+<{URI}> a owl:Ontology ;
+    dcterms:title "Biosynonyms in OWL" ;
+    dcterms:description "An ontology representation of community curated synonyms in Biosynonyms" ;
+    dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
+    rdfs:comment "Built by https://github.com/biopragmatics/biosynonyms"^^xsd:string .
+"""
+
+PREAMBLE = """\
+rdfs:label a owl:AnnotationProperty;
+    rdfs:label "label"^^xsd:string .
+
+oboInOwl:hasSynonym a owl:AnnotationProperty;
+    rdfs:label "has synonym"^^xsd:string .
+
+oboInOwl:hasExactSynonym a owl:AnnotationProperty;
+    rdfs:label "has exact synonym"^^xsd:string .
+
+oboInOwl:hasNarrowSynonym a owl:AnnotationProperty;
+    rdfs:label "has narrow synonym"^^xsd:string .
+
+oboInOwl:hasBroadSynonym a owl:AnnotationProperty;
+    rdfs:label "has broad synonym"^^xsd:string .
+
+oboInOwl:hasRelatedSynonym a owl:AnnotationProperty;
+    rdfs:label "has related synonym"^^xsd:string .
+
+oboInOwl:hasSynonymType a owl:AnnotationProperty;
+    rdfs:label "has synonym type"^^xsd:string .
+
+oboInOwl:hasDbXref a owl:AnnotationProperty;
+    rdfs:label "has database cross-reference"^^xsd:string .
+
+dcterms:contributor a owl:AnnotationProperty;
+    rdfs:label "contributor"^^xsd:string .
+
+dcterms:source a owl:AnnotationProperty;
+    rdfs:label "source"^^xsd:string .
+
+rdfs:seeAlso a owl:AnnotationProperty;
+    rdfs:label "see also"^^xsd:string .
+
+rdfs:comment a owl:AnnotationProperty;
+    rdfs:label "comment"^^xsd:string .
+
+NCBITaxon:9606 a owl:Class ;
+    rdfs:label "Homo sapiens" .
+
+orcid:0000-0003-4423-4370 a NCBITaxon:9606 ;
+    rdfs:label "Charles Tapley Hoyt"@en .
+
+orcid:0000-0001-9439-5346 a NCBITaxon:9606 ;
+    rdfs:label "Benjamin M. Gyori"@en .
+
+# See new OMO synonyms at
+# https://github.com/information-artifact-ontology/ontology-metadata/blob/master/src/templates/annotation_properties.tsv
+
+OMO:0003000 a owl:AnnotationProperty;
+    rdfs:label "abbreviation"^^xsd:string .
+
+OMO:0003001 a owl:AnnotationProperty;
+    rdfs:label "ambiguous synonym"^^xsd:string .
+
+OMO:0003002 a owl:AnnotationProperty;
+    rdfs:label "dubious synonym"^^xsd:string .
+
+OMO:0003003 a owl:AnnotationProperty;
+    rdfs:label "layperson synonym"^^xsd:string .
+
+OMO:0003004 a owl:AnnotationProperty;
+    rdfs:label "plural form"^^xsd:string .
+
+OMO:0003005 a owl:AnnotationProperty;
+    rdfs:label "UK spelling"^^xsd:string .
+
+OMO:0003006 a owl:AnnotationProperty;
+    rdfs:label "misspelling"^^xsd:string .
+
+OMO:0003007 a owl:AnnotationProperty;
+    rdfs:label "misnomer"^^xsd:string .
+
+OMO:0003008 a owl:AnnotationProperty;
+    rdfs:label "previous name"^^xsd:string .
+
+OMO:0003009 a owl:AnnotationProperty;
+    rdfs:label "legal name"^^xsd:string .
+
+OMO:0003010 a owl:AnnotationProperty;
+    rdfs:label "International Nonproprietary Name"^^xsd:string .
+
+OMO:0003011 a owl:AnnotationProperty;
+    rdfs:label "latin term"^^xsd:string .
+
+OMO:0003012 a owl:AnnotationProperty;
+    rdfs:label "acronym"^^xsd:string .
+"""
+
+
+def write_owl_rdf() -> None:
+    """Write OWL RDF in a Turtle file."""
+    with open(TTL_PATH, "w") as file:
+        _write_owl_rdf(get_positive_synonyms(), file, metadata=METADATA)
+
+
+def write_owl_rdf_gz() -> None:
+    """Write OWL RDF in a gzipped Turtle file."""
+    with gzip.open(TTL_PATH.with_suffix(".gz"), "wt") as file:
+        _write_owl_rdf(get_positive_synonyms(), file, metadata=METADATA)
+
+
+def _write_owl_rdf(
+    synonyms: list[Synonym],
+    file: TextIO,
+    *,
+    metadata: str | None = None,
+) -> None:
+    dd = defaultdict(list)
+    for synonym in tqdm(
+        synonyms, unit="synonym", unit_scale=True, desc="Indexing synonyms", leave=False
+    ):
+        dd[synonym.reference].append(synonym)
+
+    prefixes = dict(
+        # rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+        rdfs="http://www.w3.org/2000/01/rdf-schema#",
+        dcterms="http://purl.org/dc/terms/",
+        owl="http://www.w3.org/2002/07/owl#",
+        oboInOwl="http://www.geneontology.org/formats/oboInOwl#",
+        #  skos="http://www.w3.org/2004/02/skos/core#",
+        orcid="https://orcid.org/",
+        OMO="http://purl.obolibrary.org/obo/OMO_",
+        NCBITaxon="http://purl.obolibrary.org/obo/NCBITaxon_",
+        QUALO="http://purl.obolibrary.org/obo/QUALO_",
+    )
+
+    # Get all the prefixes used for references
+    extra_prefixes: set[str] = {reference.prefix for reference in dd}
+    # Add all the prefixes appearing in provenance
+    extra_prefixes.update(
+        reference.prefix
+        for synonyms in dd.values()
+        for synonym in synonyms
+        for reference in synonym.provenance
+    )
+
+    for prefix in extra_prefixes:
+        if prefix not in prefixes:
+            uri_prefix = bioregistry.get_uri_prefix(prefix)
+            if uri_prefix is None:
+                raise ValueError(
+                    f"Prefix has no URI expansion in Bioregistry: {prefix} ({bioregistry.get_name(prefix)})"
+                )
+            prefixes[prefix] = uri_prefix
+
+    for prefix, uri_prefix in prefixes.items():
+        file.write(f"@prefix {prefix}: <{uri_prefix}> .\n")
+
+    if metadata:
+        file.write(f"\n{metadata}\n")
+
+    file.write(f"\n{PREAMBLE}\n")
+
+    for reference, synonyms in dd.items():
+        mains = []
+        axiom_strs = []
+        for synonym in synonyms:
+            mains.append(f"{synonym.scope.curie} {synonym.text_for_turtle}")
+
+            axiom_parts = [
+                f"dcterms:contributor {synonym.contributor.curie}",
+                f'dcterms:source "{_clean_str(synonym.source)}"',
+            ]
+            if synonym.type:
+                axiom_parts.append(f"oboInOwl:hasSynonymType {synonym.type.curie}")
+            for rr in synonym.provenance:
+                axiom_parts.append(f"oboInOwl:hasDbXref {rr.curie}")
+            if synonym.comment:
+                axiom_parts.append(f'rdfs:comment "{_clean_str(synonym.comment)}"')
+
+            axiom_parts_str = " ;\n".join(f"    {ax}" for ax in axiom_parts) + " ."
+            axiom = f"""\
+[
+    a owl:Axiom ;
+    owl:annotatedSource {reference.curie} ;
+    owl:annotatedProperty {synonym.scope.curie} ;
+    owl:annotatedTarget {synonym.text_for_turtle} ;
+{axiom_parts_str}
+] .
+"""
+            axiom_strs.append(axiom)
+
+        file.write(f"\n{reference.curie} a owl:Class ;\n")
+        try:
+            name = next(synonym.name for synonym in synonyms if synonym.name)
+        except StopIteration:
+            pass  # could not extract a name, no worries!
+        else:
+            mains.append(f'rdfs:label "{_clean_str(name)}"')
+
+        file.write(" ;\n".join(f"    {m}" for m in mains) + " .\n")
+        if axiom_strs:
+            file.write("\n")
+        for axiom in axiom_strs:
+            file.write(dedent(axiom))
+
+
+def get_remote_curie_map(
+    path: Union[str, Path], key: str = "label", delimiter: Optional[str] = None
+) -> Mapping[Reference, str]:
+    """Get a one-to-one data column from a TSV for CURIEs."""
+    import pandas as pd
+
+    df = pd.read_csv(path, sep=delimiter or "\t")
+    return {Reference.from_curie(curie): value for curie, value in df[["curie", key]].values}
+
+
+def _main() -> None:
+    qualo_base = (
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1vTLjgYCVw6wY8mYMcZJY4KSY5"
+        "xyLWYHSaStOUfoonQvsSU_nRyzYiRJ8pYsfF7Zid5jERB08s89bdt0/pub?single=true&output=tsv"
+    )
+    names_url = f"{qualo_base}&gid=0"
+    synonyms_url = f"{qualo_base}&gid=1557592961"
+
+    names = get_remote_curie_map(names_url)
+
+    synonyms = parse_synonyms(synonyms_url, names=names)
+    qualo_path = EXPORT.joinpath("qualo_synonyms.ttl")
+    with open(qualo_path, "w") as file:
+        _write_owl_rdf(synonyms, file)
+
+    write_owl_rdf()
+
+
+if __name__ == "__main__":
+    _main()
+
+    # import bioontologies.robot
+    # bioontologies.robot.convert(TTL_PATH, OWL_PATH)

--- a/src/biosynonyms/predict.py
+++ b/src/biosynonyms/predict.py
@@ -64,7 +64,8 @@ def ensure_procesed_statements() -> Path:
     bucket = "bigmech"
     key = "indra-db/dumps/principal/2023-05-05/processed_statements.tsv.gz"
     return cast(
-        Path, MODULE.ensure_from_s3("principal", "2023-05-05", s3_bucket=bucket, s3_key=key)
+        Path,
+        MODULE.ensure_from_s3("principal", "2023-05-05", s3_bucket=bucket, s3_key=key),
     )
 
 

--- a/src/biosynonyms/resources/__init__.py
+++ b/src/biosynonyms/resources/__init__.py
@@ -169,7 +169,7 @@ class Synonym(BaseModel):
             source=row.get("source") or None,
         )
         if contributor := (row.get("contributor") or "").strip():
-            data['contributor'] = Reference(prefix="orcid", identifier=contributor)
+            data["contributor"] = Reference(prefix="orcid", identifier=contributor)
         if date := (row.get("date") or "").strip():
             data["date"] = datetime.datetime.strptime(date, "%Y-%m-%d")
 

--- a/src/biosynonyms/resources/__init__.py
+++ b/src/biosynonyms/resources/__init__.py
@@ -203,7 +203,13 @@ def parse_synonyms(
     delimiter: Optional[str] = None,
     names: Optional[Mapping[Reference, str]] = None,
 ) -> List[Synonym]:
-    """Load synonyms from a file."""
+    """Load synonyms from a file.
+
+    :param path: A local file path or URL for a biosynonyms-flavored CSV/TSV file
+    :param delimiter: The delimiter for the CSV/TSV file. Defaults to tab
+    :param names: A pre-parsed dictionary from references (i.e., prefix-luid pairs) to default labels
+    :returns: A list of synonym objects parsed from the table
+    """
     if isinstance(path, str) and any(path.startswith(schema) for schema in ("https://", "http://")):
         import requests
 
@@ -223,9 +229,9 @@ def _from_lines(
     names: Optional[Mapping[Reference, str]] = None,
 ) -> List[Synonym]:
     return [
-        Synonym.from_row(d, names=names)
-        for d in csv.DictReader(lines, delimiter=delimiter or "\t")
-        if d
+        Synonym.from_row(record, names=names)
+        for record in csv.DictReader(lines, delimiter=delimiter or "\t")
+        if record
     ]
 
 

--- a/src/biosynonyms/resources/__init__.py
+++ b/src/biosynonyms/resources/__init__.py
@@ -132,6 +132,8 @@ class Synonym(BaseModel):
     @property
     def date_str(self) -> str:
         """Get the date as a string."""
+        if self.date is None:
+            raise ValueError("date is not set")
         return self.date.strftime("%Y-%m-%d")
 
     @property

--- a/src/biosynonyms/resources/__init__.py
+++ b/src/biosynonyms/resources/__init__.py
@@ -38,7 +38,7 @@ __all__ = [
     "load_unentities",
     "write_unentities",
     # Utilities
-    "iter_gilda_terms",
+    "get_gilda_terms",
     "parse_synonyms",
 ]
 
@@ -287,7 +287,7 @@ def _from_dicts(
     return [Synonym.from_row(record, names=names) for record in dicts if record]
 
 
-def iter_gilda_terms() -> Iterable["gilda.Term"]:
+def get_gilda_terms() -> Iterable["gilda.Term"]:
     """Get Gilda terms for all positive synonyms."""
     for synonym in parse_synonyms(POSITIVES_PATH):
         yield synonym.as_gilda_term()

--- a/src/biosynonyms/resources/negatives.tsv
+++ b/src/biosynonyms/resources/negatives.tsv
@@ -1,2 +1,2 @@
-text	curie	name	references	contributor
+text	curie	name	provenance	contributor
 PI(3,4,5)P3	hgnc:22979	SLC10A3	pubmed:29623928,pubmed:20817957,pubmed:18931680,pubmed:28443090	0000-0003-4423-4370

--- a/src/biosynonyms/resources/positives.tsv
+++ b/src/biosynonyms/resources/positives.tsv
@@ -1,26 +1,26 @@
-text	curie	name	scope	type	references	contributor
-1,3-dimethylurate	chebi:133726	1,3-dimethylurate anion	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-abema	mesh:C000590451	abemaciclib	oboInOwl:hasExactSynonym			0000-0001-9439-5346
-adaptor protein cbl	interpro:IPR024162	Adaptor protein Cbl	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-Angiotensin-2	chebi:48432	angiotensin II	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-ATPase	eccode:3.6.1.3	adenosinetriphosphatase	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-ATPase	hgnc.genegroup:412	ATPases	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-cell apoptosis	go:0006915	apoptotic process	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-chronic inflammation	symp:0020026	chronic inflammation	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-IFN-\\u03b3	hgnc:5438	IFNG	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-IFN-\u03b3	hgnc:5438	IFNG	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-IL-1\\u03b2	hgnc:5992	IFNG	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-IL-1\u03b2	hgnc:5992	IFNG	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-immune cells	cl:0000738	leukocyte	oboInOwl:hasExactSynonym	OMO:0003004		0000-0003-4423-4370
-inflammatory responses	go:0006954	inflammatory response	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-neurodegeneration	hp:0002180	Neurodegeneration	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-neuroinflammation	hp:0033429	Neuroinflammation	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-NLRP3 inflammasome	complexportal:CPX-4141	NLRP3 inflammasome	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-phosphatidylinositol (3,4,5) P3	chebi:16618	1-phosphatidyl-1D-myo-inositol 3,4,5-trisphosphate	oboInOwl:hasExactSynonym		pubmed:29695532	0000-0003-4423-4370
-PI(3,4,5)P3	chebi:16618	1-phosphatidyl-1D-myo-inositol 3,4,5-trisphosphate	oboInOwl:hasExactSynonym		pubmed:29623928,pubmed:20817957,pubmed:18931680,pubmed:28443090	0000-0003-4423-4370
-TNF-\\u03b1	hgnc:11892	TNF	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-TNF-\u03b1	hgnc:11892	TNF	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-YAL021C	sgd:S000000019	CCR4	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-YDL160C	sgd:S000002319	DHH1	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-YGL122C	sgd:S000003090	NAB2	oboInOwl:hasExactSynonym			0000-0003-4423-4370
-YNL209W	sgd:S000005153	SSB2	oboInOwl:hasExactSynonym			0000-0003-4423-4370
+text	curie	name	predicate	type	provenance	contributor	language	comment	source
+1,3-dimethylurate	chebi:133726	1,3-dimethylurate anion	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+abema	mesh:C000590451	abemaciclib	oboInOwl:hasExactSynonym			0000-0001-9439-5346	en		biosynonyms
+adaptor protein cbl	interpro:IPR024162	Adaptor protein Cbl	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+Angiotensin-2	chebi:48432	angiotensin II	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+ATPase	eccode:3.6.1.3	adenosinetriphosphatase	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+ATPase	hgnc.genegroup:412	ATPases	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+cell apoptosis	go:0006915	apoptotic process	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+chronic inflammation	symp:0020026	chronic inflammation	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+IFN-\\u03b3	hgnc:5438	IFNG	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+IFN-\u03b3	hgnc:5438	IFNG	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+IL-1\\u03b2	hgnc:5992	IL1B	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+IL-1\u03b2	hgnc:5992	IL1B	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+immune cells	cl:0000738	leukocyte	oboInOwl:hasExactSynonym	OMO:0003004		0000-0003-4423-4370	en		biosynonyms
+inflammatory responses	go:0006954	inflammatory response	oboInOwl:hasExactSynonym	OMO:0003004		0000-0003-4423-4370	en		biosynonyms
+neurodegeneration	hp:0002180	Neurodegeneration	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+neuroinflammation	hp:0033429	Neuroinflammation	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+NLRP3 inflammasome	complexportal:CPX-4141	NLRP3 inflammasome	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+phosphatidylinositol (3,4,5) P3	chebi:16618	1-phosphatidyl-1D-myo-inositol 3,4,5-trisphosphate	oboInOwl:hasExactSynonym		pubmed:29695532	0000-0003-4423-4370	en		biosynonyms
+PI(3,4,5)P3	chebi:16618	1-phosphatidyl-1D-myo-inositol 3,4,5-trisphosphate	oboInOwl:hasExactSynonym		pubmed:29623928,pubmed:20817957,pubmed:18931680,pubmed:28443090	0000-0003-4423-4370	en		biosynonyms
+TNF-\\u03b1	hgnc:11892	TNF	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en	for situations when the escaping in the text is incorrect, and the unicode character string for beta is raw	biosynonyms
+TNF-\u03b1	hgnc:11892	TNF	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+YAL021C	sgd:S000000019	CCR4	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+YDL160C	sgd:S000002319	DHH1	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+YGL122C	sgd:S000003090	NAB2	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+YNL209W	sgd:S000005153	SSB2	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms

--- a/src/biosynonyms/resources/positives.tsv
+++ b/src/biosynonyms/resources/positives.tsv
@@ -1,26 +1,26 @@
-text	curie	name	scope	type	provenance	contributor	language	comment	source
-1,3-dimethylurate	chebi:133726	1,3-dimethylurate anion	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-abema	mesh:C000590451	abemaciclib	oboInOwl:hasExactSynonym			0000-0001-9439-5346	en		biosynonyms
-adaptor protein cbl	interpro:IPR024162	Adaptor protein Cbl	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-Angiotensin-2	chebi:48432	angiotensin II	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-ATPase	eccode:3.6.1.3	adenosinetriphosphatase	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-ATPase	hgnc.genegroup:412	ATPases	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-cell apoptosis	go:0006915	apoptotic process	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-chronic inflammation	symp:0020026	chronic inflammation	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-IFN-\\u03b3	hgnc:5438	IFNG	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-IFN-\u03b3	hgnc:5438	IFNG	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-IL-1\\u03b2	hgnc:5992	IL1B	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-IL-1\u03b2	hgnc:5992	IL1B	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-immune cells	cl:0000738	leukocyte	oboInOwl:hasExactSynonym	OMO:0003004		0000-0003-4423-4370	en		biosynonyms
-inflammatory responses	go:0006954	inflammatory response	oboInOwl:hasExactSynonym	OMO:0003004		0000-0003-4423-4370	en		biosynonyms
-neurodegeneration	hp:0002180	Neurodegeneration	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-neuroinflammation	hp:0033429	Neuroinflammation	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-NLRP3 inflammasome	complexportal:CPX-4141	NLRP3 inflammasome	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-phosphatidylinositol (3,4,5) P3	chebi:16618	1-phosphatidyl-1D-myo-inositol 3,4,5-trisphosphate	oboInOwl:hasExactSynonym		pubmed:29695532	0000-0003-4423-4370	en		biosynonyms
-PI(3,4,5)P3	chebi:16618	1-phosphatidyl-1D-myo-inositol 3,4,5-trisphosphate	oboInOwl:hasExactSynonym		pubmed:29623928,pubmed:20817957,pubmed:18931680,pubmed:28443090	0000-0003-4423-4370	en		biosynonyms
-TNF-\\u03b1	hgnc:11892	TNF	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en	for situations when the escaping in the text is incorrect, and the unicode character string for beta is raw	biosynonyms
-TNF-\u03b1	hgnc:11892	TNF	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-YAL021C	sgd:S000000019	CCR4	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-YDL160C	sgd:S000002319	DHH1	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-YGL122C	sgd:S000003090	NAB2	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
-YNL209W	sgd:S000005153	SSB2	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
+text	curie	name	scope	type	provenance	contributor	date	language	comment	source
+1,3-dimethylurate	chebi:133726	1,3-dimethylurate anion	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+abema	mesh:C000590451	abemaciclib	oboInOwl:hasExactSynonym			0000-0001-9439-5346		en		biosynonyms
+adaptor protein cbl	interpro:IPR024162	Adaptor protein Cbl	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+Angiotensin-2	chebi:48432	angiotensin II	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+ATPase	eccode:3.6.1.3	adenosinetriphosphatase	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+ATPase	hgnc.genegroup:412	ATPases	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+cell apoptosis	go:0006915	apoptotic process	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+chronic inflammation	symp:0020026	chronic inflammation	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+IFN-\\u03b3	hgnc:5438	IFNG	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+IFN-\u03b3	hgnc:5438	IFNG	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+IL-1\\u03b2	hgnc:5992	IL1B	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+IL-1\u03b2	hgnc:5992	IL1B	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+immune cells	cl:0000738	leukocyte	oboInOwl:hasExactSynonym	OMO:0003004		0000-0003-4423-4370		en		biosynonyms
+inflammatory responses	go:0006954	inflammatory response	oboInOwl:hasExactSynonym	OMO:0003004		0000-0003-4423-4370		en		biosynonyms
+neurodegeneration	hp:0002180	Neurodegeneration	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+neuroinflammation	hp:0033429	Neuroinflammation	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+NLRP3 inflammasome	complexportal:CPX-4141	NLRP3 inflammasome	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+phosphatidylinositol (3,4,5) P3	chebi:16618	1-phosphatidyl-1D-myo-inositol 3,4,5-trisphosphate	oboInOwl:hasExactSynonym		pubmed:29695532	0000-0003-4423-4370	2022-05-09	en		biosynonyms
+PI(3,4,5)P3	chebi:16618	1-phosphatidyl-1D-myo-inositol 3,4,5-trisphosphate	oboInOwl:hasExactSynonym		pubmed:29623928,pubmed:20817957,pubmed:18931680,pubmed:28443090	0000-0003-4423-4370	2022-05-09	en		biosynonyms
+TNF-\\u03b1	hgnc:11892	TNF	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en	for situations when the escaping in the text is incorrect, and the unicode character string for beta is raw	biosynonyms
+TNF-\u03b1	hgnc:11892	TNF	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+YAL021C	sgd:S000000019	CCR4	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+YDL160C	sgd:S000002319	DHH1	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+YGL122C	sgd:S000003090	NAB2	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms
+YNL209W	sgd:S000005153	SSB2	oboInOwl:hasExactSynonym			0000-0003-4423-4370		en		biosynonyms

--- a/src/biosynonyms/resources/positives.tsv
+++ b/src/biosynonyms/resources/positives.tsv
@@ -1,4 +1,4 @@
-text	curie	name	predicate	type	provenance	contributor	language	comment	source
+text	curie	name	scope	type	provenance	contributor	language	comment	source
 1,3-dimethylurate	chebi:133726	1,3-dimethylurate anion	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms
 abema	mesh:C000590451	abemaciclib	oboInOwl:hasExactSynonym			0000-0001-9439-5346	en		biosynonyms
 adaptor protein cbl	interpro:IPR024162	Adaptor protein Cbl	oboInOwl:hasExactSynonym			0000-0003-4423-4370	en		biosynonyms

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -44,8 +44,8 @@ class TestIntegrity(unittest.TestCase):
 
         for row_index, row in enumerate(rows, start=1):
             with self.subTest(row=row_index):
-                self.assertEqual(7, len(row))
-                text, curie, _name, scope, synonym_type, references, orcid = row
+                self.assertEqual(10, len(row))
+                text, curie, _name, scope, synonym_type, references, orcid, lang, comment, src = row
                 self.assertLess(1, len(text), msg="can not have 1 letter synonyms")
                 self.assert_curie(curie)
                 self.assertIn(scope, SYNONYM_SCOPES)
@@ -71,7 +71,7 @@ class TestIntegrity(unittest.TestCase):
 
         for row_index, row in enumerate(rows, start=1):
             with self.subTest(row=row_index):
-                self.assertEquals(5, len(row))
+                self.assertEqual(5, len(row))
                 text, curie, _name, references, orcid = row
                 self.assertLess(1, len(text), msg="can not have 1 letter synonyms")
                 self.assert_curie(curie)

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -117,7 +117,7 @@ class TestIntegrity(unittest.TestCase):
 
     def test_gilda(self):
         """Test getting tilda terms."""
-        grounder = gilda.Grounder(biosynonyms.iter_gilda_terms())
+        grounder = gilda.Grounder(biosynonyms.get_gilda_terms())
         scored_matches = grounder.ground("YAL021C")
         self.assertEqual(1, len(scored_matches))
         self.assertEqual("sgd", scored_matches[0].term.db)

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -117,7 +117,7 @@ class TestIntegrity(unittest.TestCase):
 
     def test_gilda(self):
         """Test getting tilda terms."""
-        grounder = gilda.Grounder(list(biosynonyms.get_gilda_terms()))
+        grounder = gilda.Grounder(biosynonyms.iter_gilda_terms())
         scored_matches = grounder.ground("YAL021C")
         self.assertEqual(1, len(scored_matches))
         self.assertEqual("sgd", scored_matches[0].term.db)

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -44,7 +44,7 @@ class TestIntegrity(unittest.TestCase):
 
         for row_index, row in enumerate(rows, start=1):
             with self.subTest(row=row_index):
-                self.assertEqual(10, len(row))
+                self.assertEqual(11, len(row))
                 (
                     text,
                     curie,
@@ -53,6 +53,7 @@ class TestIntegrity(unittest.TestCase):
                     synonym_type,
                     references,
                     orcid,
+                    date,
                     lang,
                     comment,
                     src,
@@ -66,6 +67,8 @@ class TestIntegrity(unittest.TestCase):
                     reference = reference.strip()
                     self.assert_curie(reference)
                 self.assert_curie(f"orcid:{orcid}")
+                if date:
+                    self.assertRegex(date, "\\d{4}-\\d{2}-\\d{2}")
 
         # test sorted
         self.assertEqual(sorted(rows, key=sort_key), rows, msg="synonyms are not properly sorted")

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -45,7 +45,18 @@ class TestIntegrity(unittest.TestCase):
         for row_index, row in enumerate(rows, start=1):
             with self.subTest(row=row_index):
                 self.assertEqual(10, len(row))
-                text, curie, _name, scope, synonym_type, references, orcid, lang, comment, src = row
+                (
+                    text,
+                    curie,
+                    _name,
+                    scope,
+                    synonym_type,
+                    references,
+                    orcid,
+                    lang,
+                    comment,
+                    src,
+                ) = row
                 self.assertLess(1, len(text), msg="can not have 1 letter synonyms")
                 self.assert_curie(curie)
                 self.assertIn(scope, SYNONYM_SCOPES)
@@ -82,7 +93,9 @@ class TestIntegrity(unittest.TestCase):
 
         # test sorted
         self.assertEqual(
-            sorted(rows, key=sort_key), rows, msg="negative synonyms are not properly sorted"
+            sorted(rows, key=sort_key),
+            rows,
+            msg="negative synonyms are not properly sorted",
         )
 
         # test no duplicates

--- a/tox.ini
+++ b/tox.ini
@@ -19,12 +19,12 @@ envlist =
     flake8
     mypy
     # documentation linters/checkers
-    doc8
+    # doc8
     docstr-coverage
-    docs-test
+    # docs-test
     # the actual tests
     py
-    doctests
+    # doctests
     # always keep coverage-report last
     # coverage-report
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,8 +23,7 @@ envlist =
     docstr-coverage
     docs-test
     # the actual tests
-    py-pydantic1
-    py-pydantic2
+    py
     doctests
     # always keep coverage-report last
     # coverage-report
@@ -36,9 +35,6 @@ commands =
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine
     coverage xml
-deps =
-    pydantic1: pydantic<2.0
-    pydantic2: pydantic>=2.0
 extras =
     tests
     pandas
@@ -87,7 +83,7 @@ description = Check that the MANIFEST.in is written properly and give feedback o
 skip_install = true
 deps =
     darglint
-    flake8<5.0.0
+    flake8
     flake8-black
     flake8-bandit
     flake8-bugbear
@@ -113,6 +109,7 @@ description = Run the pyroma tool to check the package friendliness of the proje
 deps =
     mypy
     pydantic
+    types-requests
 skip_install = true
 commands = mypy --install-types --non-interactive --ignore-missing-imports --strict src/
 description = Run the mypy tool to check static typing on the project.


### PR DESCRIPTION
This PR does the following:

1. Extends the data model with the following fields:
   - language (2 letter ISO code)
   - date of curation
2. fixes inconsistent references to the `provenance` column
3. Makes parsing more flexible to different datatypes (including Numbers sheets)
4. Add OWL export
5. Update to Pydantic 2 only
6. Better I/O with `gilda.Term`