### PR TITLE
Rename `Synonym` to `LiteralMapping`

### DIFF
--- a/src/biosynonyms/__init__.py
+++ b/src/biosynonyms/__init__.py
@@ -3,12 +3,10 @@
 from .model import (
     LiteralMapping,
     LiteralMappingTuple,
-    Synonym,
-    SynonymTuple,
-    grounder_from_synonyms,
-    group_synonyms,
-    parse_synonyms,
-    write_synonyms,
+    grounder_from_literal_mappings,
+    group_literal_mappings,
+    read_literal_mappings,
+    write_literal_mappings,
 )
 from .resources import (
     get_gilda_terms,
@@ -21,15 +19,13 @@ from .resources import (
 __all__ = [
     "LiteralMapping",
     "LiteralMappingTuple",
-    "Synonym",
-    "SynonymTuple",
     "get_gilda_terms",
     "get_grounder",
     "get_negative_synonyms",
     "get_positive_synonyms",
-    "grounder_from_synonyms",
-    "group_synonyms",
+    "grounder_from_literal_mappings",
+    "group_literal_mappings",
     "load_unentities",
-    "parse_synonyms",
-    "write_synonyms",
+    "read_literal_mappings",
+    "write_literal_mappings",
 ]

--- a/src/biosynonyms/__init__.py
+++ b/src/biosynonyms/__init__.py
@@ -1,6 +1,8 @@
 """Code for biosynonyms."""
 
 from .model import (
+    LiteralMapping,
+    LiteralMappingTuple,
     Synonym,
     SynonymTuple,
     grounder_from_synonyms,
@@ -17,6 +19,8 @@ from .resources import (
 )
 
 __all__ = [
+    "LiteralMapping",
+    "LiteralMappingTuple",
     "Synonym",
     "SynonymTuple",
     "get_gilda_terms",

--- a/src/biosynonyms/generate_owl.py
+++ b/src/biosynonyms/generate_owl.py
@@ -14,7 +14,7 @@ import bioregistry
 from curies import Reference
 from typing_extensions import Doc
 
-from biosynonyms.model import LiteralMapping, group_synonyms
+from biosynonyms.model import LiteralMapping, group_literal_mappings
 from biosynonyms.resources import get_positive_synonyms
 
 HERE = Path(__file__).parent.resolve()
@@ -120,11 +120,11 @@ OMO:0003012 a owl:AnnotationProperty;
 """
 
 
-def _text_for_turtle(synonym: LiteralMapping) -> str:
+def _text_for_turtle(literal_mapping: LiteralMapping) -> str:
     """Get the text ready for an object slot in Turtle, with optional language tag."""
-    tt = f'"{_clean_str(synonym.text)}"'
-    if synonym.language:
-        tt += f"@{synonym.language}"
+    tt = f'"{_clean_str(literal_mapping.text)}"'
+    if literal_mapping.language:
+        tt += f"@{literal_mapping.language}"
     return tt
 
 
@@ -157,9 +157,9 @@ DEFAULT_PREFIXES: dict[str, str] = {
 def _get_prefixes(dd: dict[Reference, list[LiteralMapping]]) -> set[str]:
     return {
         reference.prefix
-        for synonyms in dd.values()
-        for synonym in synonyms
-        for reference in synonym.get_all_references()
+        for literal_mappings in dd.values()
+        for literal_mapping in literal_mappings
+        for reference in literal_mapping.get_all_references()
     }
 
 
@@ -197,21 +197,21 @@ def iter_prefix_map(
     return sorted(chained_prefix_map.items(), key=lambda i: i[0].casefold())
 
 
-def get_axiom_str(reference: Reference, synonym: LiteralMapping) -> str | None:
+def get_axiom_str(reference: Reference, literal_mapping: LiteralMapping) -> str | None:
     """Get the axiom string for a synonym."""
     axiom_parts = []
-    if synonym.contributor:
-        axiom_parts.append(f"dcterms:contributor {synonym.contributor.curie}")
-    if synonym.date:
-        axiom_parts.append(f'dcterms:date "{synonym.date_str}"^^xsd:date')
-    if synonym.source:
-        axiom_parts.append(f'dcterms:source "{_clean_str(synonym.source)}"')
-    if synonym.type:
-        axiom_parts.append(f"oboInOwl:hasSynonymType {synonym.type.curie}")
-    for rr in synonym.provenance:
+    if literal_mapping.contributor:
+        axiom_parts.append(f"dcterms:contributor {literal_mapping.contributor.curie}")
+    if literal_mapping.date:
+        axiom_parts.append(f'dcterms:date "{literal_mapping.date_str}"^^xsd:date')
+    if literal_mapping.source:
+        axiom_parts.append(f'dcterms:source "{_clean_str(literal_mapping.source)}"')
+    if literal_mapping.type:
+        axiom_parts.append(f"oboInOwl:hasSynonymType {literal_mapping.type.curie}")
+    for rr in literal_mapping.provenance:
         axiom_parts.append(f"oboInOwl:hasDbXref {rr.curie}")
-    if synonym.comment:
-        axiom_parts.append(f'rdfs:comment "{_clean_str(synonym.comment)}"')
+    if literal_mapping.comment:
+        axiom_parts.append(f'rdfs:comment "{_clean_str(literal_mapping.comment)}"')
 
     if not axiom_parts:
         # if there's no additional context to add, then we don't need to make an axiom
@@ -222,8 +222,8 @@ def get_axiom_str(reference: Reference, synonym: LiteralMapping) -> str | None:
 [
     a owl:Axiom ;
     owl:annotatedSource {reference.curie} ;
-    owl:annotatedProperty {synonym.predicate.curie} ;
-    owl:annotatedTarget {_text_for_turtle(synonym)} ;
+    owl:annotatedProperty {literal_mapping.predicate.curie} ;
+    owl:annotatedTarget {_text_for_turtle(literal_mapping)} ;
 {axiom_parts_str}
 ] .
 """
@@ -231,7 +231,7 @@ def get_axiom_str(reference: Reference, synonym: LiteralMapping) -> str | None:
 
 
 def _write_owl_rdf(  # noqa:C901
-    synonyms: list[LiteralMapping],
+    literal_mappings: list[LiteralMapping],
     file: TextIO,
     *,
     prefix_definitions: Annotated[
@@ -241,7 +241,7 @@ def _write_owl_rdf(  # noqa:C901
     metadata: str | None = None,
     prefix_map: dict[str, str] | None = None,
 ) -> None:
-    dd = group_synonyms(synonyms)
+    dd = group_literal_mappings(literal_mappings)
 
     if prefix_definitions:
         write_prefix_map(_get_prefixes(dd), file=file, prefix_map=prefix_map)
@@ -251,18 +251,18 @@ def _write_owl_rdf(  # noqa:C901
 
     file.write(f"\n{PREAMBLE}\n")
 
-    for reference, synonyms in dd.items():
+    for reference, literal_mappings in dd.items():
         mains: list[str] = []
         axiom_strs: list[str] = []
-        for synonym in synonyms:
-            mains.append(f"{synonym.predicate.curie} {_text_for_turtle(synonym)}")
-            if axiom_str := get_axiom_str(reference, synonym):
+        for literal_mapping in literal_mappings:
+            mains.append(f"{literal_mapping.predicate.curie} {_text_for_turtle(literal_mapping)}")
+            if axiom_str := get_axiom_str(reference, literal_mapping):
                 axiom_strs.append(axiom_str)
 
         if class_definitions:
             file.write(f"\n{reference.curie} a owl:Class ;\n")
             try:
-                name = next(synonym.name for synonym in synonyms if synonym.name)
+                name = next(synonym.name for synonym in literal_mappings if synonym.name)
             except StopIteration:
                 pass  # could not extract a name, no worries!
             else:

--- a/src/biosynonyms/generate_owl.py
+++ b/src/biosynonyms/generate_owl.py
@@ -14,7 +14,7 @@ import bioregistry
 from curies import Reference
 from typing_extensions import Doc
 
-from biosynonyms.model import Synonym, group_synonyms
+from biosynonyms.model import LiteralMapping, group_synonyms
 from biosynonyms.resources import get_positive_synonyms
 
 HERE = Path(__file__).parent.resolve()
@@ -120,7 +120,7 @@ OMO:0003012 a owl:AnnotationProperty;
 """
 
 
-def _text_for_turtle(synonym: Synonym) -> str:
+def _text_for_turtle(synonym: LiteralMapping) -> str:
     """Get the text ready for an object slot in Turtle, with optional language tag."""
     tt = f'"{_clean_str(synonym.text)}"'
     if synonym.language:
@@ -154,7 +154,7 @@ DEFAULT_PREFIXES: dict[str, str] = {
 }
 
 
-def _get_prefixes(dd: dict[Reference, list[Synonym]]) -> set[str]:
+def _get_prefixes(dd: dict[Reference, list[LiteralMapping]]) -> set[str]:
     return {
         reference.prefix
         for synonyms in dd.values()
@@ -197,7 +197,7 @@ def iter_prefix_map(
     return sorted(chained_prefix_map.items(), key=lambda i: i[0].casefold())
 
 
-def get_axiom_str(reference: Reference, synonym: Synonym) -> str | None:
+def get_axiom_str(reference: Reference, synonym: LiteralMapping) -> str | None:
     """Get the axiom string for a synonym."""
     axiom_parts = []
     if synonym.contributor:
@@ -231,7 +231,7 @@ def get_axiom_str(reference: Reference, synonym: Synonym) -> str | None:
 
 
 def _write_owl_rdf(  # noqa:C901
-    synonyms: list[Synonym],
+    synonyms: list[LiteralMapping],
     file: TextIO,
     *,
     prefix_definitions: Annotated[

--- a/src/biosynonyms/lint.py
+++ b/src/biosynonyms/lint.py
@@ -1,6 +1,6 @@
 """Sort the synonyms file."""
 
-from biosynonyms.model import lint_synonyms
+from biosynonyms.model import lint_literal_mappings
 
 from .resources import (
     NEGATIVES_PATH,
@@ -11,8 +11,8 @@ from .resources import (
 
 
 def _main() -> None:
-    lint_synonyms(POSITIVES_PATH)
-    lint_synonyms(NEGATIVES_PATH)
+    lint_literal_mappings(POSITIVES_PATH)
+    lint_literal_mappings(NEGATIVES_PATH)
     write_unentities(list(_load_unentities()))
 
 

--- a/src/biosynonyms/resources/__init__.py
+++ b/src/biosynonyms/resources/__init__.py
@@ -6,7 +6,12 @@ from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-from biosynonyms.model import PREDICATES, LiteralMapping, grounder_from_synonyms, parse_synonyms
+from biosynonyms.model import (
+    PREDICATES,
+    LiteralMapping,
+    grounder_from_literal_mappings,
+    read_literal_mappings,
+)
 
 if TYPE_CHECKING:
     import gilda
@@ -54,12 +59,12 @@ def write_unentities(rows: Iterable[tuple[str, str]]) -> None:
 
 def get_positive_synonyms() -> list[LiteralMapping]:
     """Get positive synonyms curated in Biosynonyms."""
-    return parse_synonyms(POSITIVES_PATH)
+    return read_literal_mappings(POSITIVES_PATH)
 
 
 def get_negative_synonyms() -> list[LiteralMapping]:
     """Get negative synonyms curated in Biosynonyms."""
-    return parse_synonyms(NEGATIVES_PATH)
+    return read_literal_mappings(NEGATIVES_PATH)
 
 
 def get_gilda_terms() -> list[gilda.Term]:
@@ -69,4 +74,4 @@ def get_gilda_terms() -> list[gilda.Term]:
 
 def get_grounder() -> gilda.Groudner:
     """Get a grounder from all positive synonyms."""
-    return grounder_from_synonyms(get_positive_synonyms())
+    return grounder_from_literal_mappings(get_positive_synonyms())

--- a/src/biosynonyms/resources/__init__.py
+++ b/src/biosynonyms/resources/__init__.py
@@ -6,7 +6,7 @@ from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
-from biosynonyms.model import PREDICATES, Synonym, grounder_from_synonyms, parse_synonyms
+from biosynonyms.model import PREDICATES, LiteralMapping, grounder_from_synonyms, parse_synonyms
 
 if TYPE_CHECKING:
     import gilda
@@ -52,12 +52,12 @@ def write_unentities(rows: Iterable[tuple[str, str]]) -> None:
             print(*row, sep="\t", file=file)
 
 
-def get_positive_synonyms() -> list[Synonym]:
+def get_positive_synonyms() -> list[LiteralMapping]:
     """Get positive synonyms curated in Biosynonyms."""
     return parse_synonyms(POSITIVES_PATH)
 
 
-def get_negative_synonyms() -> list[Synonym]:
+def get_negative_synonyms() -> list[LiteralMapping]:
     """Get negative synonyms curated in Biosynonyms."""
     return parse_synonyms(NEGATIVES_PATH)
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -138,7 +138,7 @@ class TestIntegrity(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as d:
             path = Path(d).joinpath("test.tsv")
-            biosynonyms.write_synonyms(path, synonyms)
-            reloaded_synonyms = biosynonyms.parse_synonyms(path)
+            biosynonyms.write_literal_mappings(path, synonyms)
+            reloaded_synonyms = biosynonyms.read_literal_mappings(path)
 
         self.assertEqual(synonyms, reloaded_synonyms)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -32,7 +32,9 @@ class TestModel(unittest.TestCase):
 
     def test_gilda_name(self) -> None:
         """Test getting gilda terms."""
-        literal_mapping = LiteralMapping(text="test", predicate=v.has_label, reference=TEST_REFERENCE)
+        literal_mapping = LiteralMapping(
+            text="test", predicate=v.has_label, reference=TEST_REFERENCE
+        )
         gilda_term = literal_mapping.to_gilda()
         self.assertEqual("name", gilda_term.status)
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,7 +5,7 @@ import unittest
 from curies import NamedReference
 from curies import vocabulary as v
 
-from biosynonyms.model import DEFAULT_PREDICATE, Synonym
+from biosynonyms.model import DEFAULT_PREDICATE, LiteralMapping
 
 TEST_REFERENCE = NamedReference.from_curie("test:1", "test")
 
@@ -15,46 +15,46 @@ class TestModel(unittest.TestCase):
 
     def test_gilda_synonym(self) -> None:
         """Test getting gilda terms."""
-        synonym = Synonym(
+        literal_mapping = LiteralMapping(
             text="tests",
             predicate=v.has_exact_synonym,
             type=v.plural_form,
             reference=TEST_REFERENCE,
         )
-        gilda_term = synonym.to_gilda()
+        gilda_term = literal_mapping.to_gilda()
         self.assertEqual("synonym", gilda_term.status)
 
         # the predicate and plural form information gets lost in the round trio
-        synonym_re_expected = Synonym(
+        literal_mapping_expected = LiteralMapping(
             text="tests", predicate=DEFAULT_PREDICATE, reference=TEST_REFERENCE
         )
-        self.assertEqual(synonym_re_expected, Synonym.from_gilda(gilda_term))
+        self.assertEqual(literal_mapping_expected, LiteralMapping.from_gilda(gilda_term))
 
     def test_gilda_name(self) -> None:
         """Test getting gilda terms."""
-        synonym = Synonym(text="test", predicate=v.has_label, reference=TEST_REFERENCE)
-        gilda_term = synonym.to_gilda()
+        literal_mapping = LiteralMapping(text="test", predicate=v.has_label, reference=TEST_REFERENCE)
+        gilda_term = literal_mapping.to_gilda()
         self.assertEqual("name", gilda_term.status)
 
-        self.assertEqual(synonym, Synonym.from_gilda(gilda_term))
+        self.assertEqual(literal_mapping, LiteralMapping.from_gilda(gilda_term))
 
     def test_gilda_former_name(self) -> None:
         """Test getting gilda terms."""
         self.maxDiff = None
-        synonym = Synonym(
+        literal_mapping = LiteralMapping(
             text="old test",
             predicate=v.has_exact_synonym,
             reference=TEST_REFERENCE,
             type=v.previous_name,
         )
-        gilda_term = synonym.to_gilda()
+        gilda_term = literal_mapping.to_gilda()
         self.assertEqual("former_name", gilda_term.status)
 
         # the predicate gets lost in round trip
-        synonym_re_expected = Synonym(
+        literal_mapping_expected = LiteralMapping(
             text="old test",
             predicate=DEFAULT_PREDICATE,
             type=v.previous_name,
             reference=TEST_REFERENCE,
         )
-        self.assertEqual(synonym_re_expected, Synonym.from_gilda(gilda_term))
+        self.assertEqual(literal_mapping_expected, LiteralMapping.from_gilda(gilda_term))


### PR DESCRIPTION
This PR renames the main Synonym class to LiteralMapping to better match SSSOM terminology